### PR TITLE
Python3: Use bytes, instead of strings on Windows too.

### DIFF
--- a/src/ZEO/zrpc/trigger.py
+++ b/src/ZEO/zrpc/trigger.py
@@ -21,7 +21,7 @@ import socket
 import errno
 
 from ZODB.utils import positive_id
-from ZEO._compat import thread, get_ident
+from ZEO._compat import thread, get_ident, ascii_bytes
 
 # Original comments follow; they're hard to follow in the context of
 # ZEO's use of triggers.  TODO:  rewrite from a ZEO perspective.
@@ -135,6 +135,9 @@ class _triggerbase(object):
     def __repr__(self):
         return '<select-trigger (%s) at %x>' % (self.kind, positive_id(self))
 
+# Added for Python 3.2 compatibility.
+TRIGGER_CHARACTER = ascii_bytes('x')
+
 if os.name == 'posix':
 
     class trigger(_triggerbase, asyncore.file_dispatcher):
@@ -159,7 +162,7 @@ if os.name == 'posix':
             asyncore.file_dispatcher.close(self)
 
         def _physical_pull(self):
-            os.write(self.trigger, b'x')
+            os.write(self.trigger, TRIGGER_CHARACTER)
 
 else:
     # Windows version; uses just sockets, because a pipe isn't select'able
@@ -232,4 +235,4 @@ else:
             self.trigger.close()
 
         def _physical_pull(self):
-            self.trigger.send(b'x')
+            self.trigger.send(TRIGGER_CHARACTER)

--- a/src/ZEO/zrpc/trigger.py
+++ b/src/ZEO/zrpc/trigger.py
@@ -232,4 +232,4 @@ else:
             self.trigger.close()
 
         def _physical_pull(self):
-            self.trigger.send('x')
+            self.trigger.send(b'x')

--- a/src/ZEO/zrpc/trigger.py
+++ b/src/ZEO/zrpc/trigger.py
@@ -21,7 +21,9 @@ import socket
 import errno
 
 from ZODB.utils import positive_id
-from ZEO._compat import thread, get_ident, ascii_bytes
+from ZODB._compat import ascii_bytes
+from ZEO._compat import thread, get_ident
+
 
 # Original comments follow; they're hard to follow in the context of
 # ZEO's use of triggers.  TODO:  rewrite from a ZEO perspective.


### PR DESCRIPTION
Seems that a leftover when upgading the code to support Python 3, the Unix version was updated but not the windows side.

UNIX sIde already uses bytes:

        def _physical_pull(self):
            os.write(self.trigger, b'x')

The error spitted if this patch is not applied is:

    Exception in thread Connect([(<AddressFamily.AF_INET: 2>, ['127.0.0.1', 4881])]):
    Traceback (most recent call last):
      File "E:\Dropbox\Projects\Python-x64-3.5.0\lib\threading.py", line 923, in _bootstrap_inner
        self.run()
      File "E:\Dropbox\Projects\Python-x64-3.5.0\lib\site-packages\ZEO\zrpc\client.py", line 390, in run
        success = self.try_connecting(attempt_timeout)
      File "E:\Dropbox\Projects\Python-x64-3.5.0\lib\site-packages\ZEO\zrpc\client.py", line 421, in try_connecting
        r = self._connect_wrappers(wrappers, deadline)
      File "E:\Dropbox\Projects\Python-x64-3.5.0\lib\site-packages\ZEO\zrpc\client.py", line 503, in _connect_wrappers
        wrap.connect_procedure()
      File "E:\Dropbox\Projects\Python-x64-3.5.0\lib\site-packages\ZEO\zrpc\client.py", line 589, in connect_procedure
        self.test_connection()
      File "E:\Dropbox\Projects\Python-x64-3.5.0\lib\site-packages\ZEO\zrpc\client.py", line 597, in test_connection
        self.conn = ManagedClientConnection(self.sock, self.addr, self.mgr)
      File "E:\Dropbox\Projects\Python-x64-3.5.0\lib\site-packages\ZEO\zrpc\connection.py", line 713, in __init__
        self.call_from_thread()
      File "E:\Dropbox\Projects\Python-x64-3.5.0\lib\site-packages\ZEO\zrpc\trigger.py", line 106, in pull_trigger
        self._physical_pull()
      File "E:\Dropbox\Projects\Python-x64-3.5.0\lib\site-packages\ZEO\zrpc\trigger.py", line 235, in _physical_pull
        self.trigger.send('x')
    TypeError: a bytes-like object is required, not 'str'