### PR TITLE
Drop support for Python 2.6 and 3.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 language: python
 sudo: false
 python:
-    - 2.6
     - 2.7
-    - 3.2
     - 3.3
     - 3.4
     - pypy
 install:
-    - pip install -U setuptools distribute
+    - pip install -U setuptools
     - python bootstrap.py
     - bin/buildout
 script:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 4.2.0 (unreleased)
 ------------------
 
-- TBD
+- Drop support for Python 2.6 and 3.2.
 
 4.2.0b1 (2015-06-05)
 --------------------

--- a/setup.py
+++ b/setup.py
@@ -18,19 +18,22 @@ from setuptools import setup, find_packages
 import os
 import sys
 
-if sys.version_info < (2, 6):
-    print("This version of ZEO requires Python 2.6 or higher")
+if sys.version_info < (2, 7):
+    print("This version of ZEO requires Python 2.7 or higher")
     sys.exit(0)
+
+if (3, 0) < sys.version_info < 3.3:
+    print("This version of ZEO requires Python 3.3 or higher")
+    sys.exit(0)
+
 
 classifiers = """\
 Intended Audience :: Developers
 License :: OSI Approved :: Zope Public License
 Programming Language :: Python
 Programming Language :: Python :: 2
-Programming Language :: Python :: 2.6
 Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.2
 Programming Language :: Python :: 3.3
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: Implementation :: CPython

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if sys.version_info < (2, 7):
     print("This version of ZEO requires Python 2.7 or higher")
     sys.exit(0)
 
-if (3, 0) < sys.version_info < 3.3:
+if (3, 0) < sys.version_info < (3, 3):
     print("This version of ZEO requires Python 3.3 or higher")
     sys.exit(0)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py26,py27,py32,py33,py34,pypy,simple
+    py27,py33,py34,pypy,simple
 
 [testenv]
 commands =
@@ -26,5 +26,5 @@ deps =
 basepython =
     python2.7
 commands =
-    python setup.py test -q
+    python setup.py -q test -q
 deps = {[testenv]deps}


### PR DESCRIPTION
- 2.6 is long out-of-maintenance, and a security quagmire.

- 3.2 cannot be tested on Travis.