### PR TITLE
AttributeError 'server' when StorageServer creation fails

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changelog
 
 - Drop support for Python 2.6 and 3.2.
 
+- Fix AttributeError: 'ZEOServer' object has no attribute 'server' when
+  StorageServer creation fails.
+
 4.2.0b1 (2015-06-05)
 --------------------
 

--- a/src/ZEO/runzeo.py
+++ b/src/ZEO/runzeo.py
@@ -150,6 +150,7 @@ class ZEOServer:
 
     def __init__(self, options):
         self.options = options
+        self.server = None
 
     def main(self):
         self.setup_default_logging()
@@ -162,7 +163,7 @@ class ZEOServer:
             self.create_server()
             self.loop_forever()
         finally:
-            self.server.close()
+            self.close_server()
             self.clear_socket()
             self.remove_pidfile()
 
@@ -261,6 +262,10 @@ class ZEOServer:
             print("testing exit immediately")
         else:
             self.server.loop()
+
+    def close_server(self):
+        if self.server is not None:
+            self.server.close()
 
     def handle_sigterm(self):
         log("terminated by SIGTERM")

--- a/src/ZEO/tests/testZEOServer.py
+++ b/src/ZEO/tests/testZEOServer.py
@@ -1,0 +1,76 @@
+#
+# Fix AttributeError: 'ZEOServer' object has no attribute 'server' in
+# ZEOServer.main
+#
+import unittest
+
+from ZEO.runzeo import ZEOServer
+
+
+class TestStorageServer:
+
+    def __init__(self, fail_create_server):
+        self.called = []
+        if fail_create_server: raise RuntimeError()
+
+    def close(self):
+        self.called.append("close")
+
+
+class TestZEOServer(ZEOServer):
+
+    def __init__(self, fail_create_server=False, fail_loop_forever=False):
+        ZEOServer.__init__(self, None)
+        self.called = []
+        self.fail_create_server = fail_create_server
+        self.fail_loop_forever = fail_loop_forever
+
+    def setup_default_logging(self):
+        self.called.append("setup_default_logging")
+
+    def check_socket(self):
+        self.called.append("check_socket")
+
+    def clear_socket(self):
+        self.called.append("clear_socket")
+
+    def make_pidfile(self):
+        self.called.append("make_pidfile")
+
+    def open_storages(self):
+        self.called.append("open_storages")
+
+    def setup_signals(self):
+        self.called.append("setup_signals")
+
+    def create_server(self):
+        self.called.append("create_server")
+        self.server = TestStorageServer(self.fail_create_server)
+
+    def loop_forever(self):
+        self.called.append("loop_forever")
+        if self.fail_loop_forever: raise RuntimeError()
+
+    def close_server(self):
+        self.called.append("close_server")
+        ZEOServer.close_server(self)
+
+    def clear_socket(self):
+        self.called.append("clear_socket")
+
+    def remove_pidfile(self):
+        self.called.append("remove_pidfile")
+
+
+class AttributeErrorTests(unittest.TestCase):
+
+    def testFailCreateServer(self):
+        # Demonstrate the AttributeError
+        zeo = TestZEOServer(fail_create_server=True)
+        self.assertRaises(RuntimeError, zeo.main)
+
+
+def test_suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(AttributeErrorTests))
+    return suite


### PR DESCRIPTION
When `StorageServer.__init__` fails with an exception, the error is masked by a subsequent AttributeError: 'ZEOServer' object has no attribute 'server'.

I propose to add a close_server function to ZEOServer, which can handle the case of non-existing server. This is also for the benefit of subclasses, which get better access to the server lifecycle.
