### PR TITLE
Load uses load before

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changelog
   with regard to the load lock.  This allowes ZEO to work with the
   upcoming ZODB 5, which used loadbefore rather than load.
 
-  Reimplemented load using loadBefore, this testing loadBefore
+  Reimplemented load using loadBefore, thus testing loadBefore
   extensively via existing tests.
 
 - Fixed: the ZEO cache loadBefore method failed to utilize current data.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,15 @@ Changelog
 4.2.0 (unreleased)
 ------------------
 
+- Changed loadBefore to operate more like load behaved, especially
+  with regard to the load lock.  This allowes ZEO to work with the
+  upcoming ZODB 5, which used loadbefore rather than load.
+
+  Reimplemented load using loadBefore, this testing loadBefore
+  extensively via existing tests.
+
+- Fixed: the ZEO cache loadBefore method failed to utilize current data.
+
 - Drop support for Python 2.6 and 3.2.
 
 4.2.0b1 (2015-06-05)

--- a/src/ZEO/ClientStorage.py
+++ b/src/ZEO/ClientStorage.py
@@ -845,12 +845,11 @@ class ClientStorage(object):
 
             result = self._server.loadBefore(oid, tid)
 
-            if result:
-                with self._lock:    # for atomic processing of invalidations
-                    if self._load_status:
-                        data, tid, end = result
-                        self._cache.store(oid, tid, end, data)
-                    self._load_oid = None
+            with self._lock:    # for atomic processing of invalidations
+                if result and self._load_status:
+                    data, tid, end = result
+                    self._cache.store(oid, tid, end, data)
+                self._load_oid = None
 
         return result
 

--- a/src/ZEO/cache.py
+++ b/src/ZEO/cache.py
@@ -494,7 +494,7 @@ class ClientCache(object):
     # @defreturn 3-tuple: (string, string, string)
 
     @locked
-    def load(self, oid):
+    def load(self, oid, before_tid=None):
         ofs = self.current.get(oid)
         if ofs is None:
             self._trace(0x20, oid)
@@ -508,6 +508,9 @@ class ClientCache(object):
         assert saved_oid == oid, (ofs, self.f.tell(), oid, saved_oid)
         assert end_tid == z64, (ofs, self.f.tell(), oid, tid, end_tid)
         assert lver == 0, "Versions aren't supported"
+
+        if before_tid and tid >= before_tid:
+            return None
 
         data = read(ldata)
         assert len(data) == ldata, (ofs, self.f.tell(), oid, len(data), ldata)
@@ -550,13 +553,22 @@ class ClientCache(object):
     def loadBefore(self, oid, before_tid):
         noncurrent_for_oid = self.noncurrent.get(u64(oid))
         if noncurrent_for_oid is None:
-            self._trace(0x24, oid, "", before_tid)
-            return None
+            result = self.load(oid, before_tid)
+            if result:
+                return result[0], result[1], None
+            else:
+                self._trace(0x24, oid, "", before_tid)
+                return result
 
         items = noncurrent_for_oid.items(None, u64(before_tid)-1)
         if not items:
-            self._trace(0x24, oid, "", before_tid)
-            return None
+            result = self.load(oid, before_tid)
+            if result:
+                return result[0], result[1], None
+            else:
+                self._trace(0x24, oid, "", before_tid)
+                return result
+
         tid, ofs = items[-1]
 
         self.f.seek(ofs)
@@ -577,8 +589,12 @@ class ClientCache(object):
         assert read(8) == oid, (ofs, self.f.tell(), oid)
 
         if end_tid < before_tid:
-            self._trace(0x24, oid, "", before_tid)
-            return None
+            result = self.load(oid, before_tid)
+            if result:
+                return result[0], result[1], None
+            else:
+                self._trace(0x24, oid, "", before_tid)
+                return result
 
         self._n_accesses += 1
         self._trace(0x26, oid, "", saved_tid)

--- a/src/ZEO/zrpc/connection.py
+++ b/src/ZEO/zrpc/connection.py
@@ -242,19 +242,24 @@ class Connection(smac.SizedMessageAsyncConnection, object):
     #         Undone oid info returned by vote.
     #
     # Z3101 -- checkCurrentSerialInTransaction
+    #
+    # Z4 -- checkCurrentSerialInTransaction
+    #       No-longer call load.
 
     # Protocol variables:
     # Our preferred protocol.
-    current_protocol = b"Z3101"
+    current_protocol = b"Z4"
 
     # If we're a client, an exhaustive list of the server protocols we
     # can accept.
-    servers_we_can_talk_to = [b"Z308", b"Z309", b"Z310", current_protocol]
+    servers_we_can_talk_to = [b"Z308", b"Z309", b"Z310", b"Z3101",
+                              current_protocol]
 
     # If we're a server, an exhaustive list of the client protocols we
     # can accept.
     clients_we_can_talk_to = [
-        b"Z200", b"Z201", b"Z303", b"Z308", b"Z309", b"Z310", current_protocol]
+        b"Z200", b"Z201", b"Z303", b"Z308", b"Z309", b"Z310", b"Z3101",
+        current_protocol]
 
     # This is pretty excruciating.  Details:
     #


### PR DESCRIPTION
Changed loadBefore to operate more like load behaved, especially
with regard to the load lock.  This allows ZEO to work with the
upcoming ZODB 5, which used loadBefore rather than load.

Reimplemented load using loadBefore, this testing loadBefore
extensively via existing tests.