### PR TITLE
Zodb5

### DIFF
--- a/src/ZEO/ClientStorage.py
+++ b/src/ZEO/ClientStorage.py
@@ -1119,7 +1119,8 @@ class ClientStorage(object):
             self._tpc_cond.release()
 
     def lastTransaction(self):
-        return self._cache.getLastTid()
+        with self._lock:
+            return self._cache.getLastTid()
 
     def tpc_abort(self, txn):
         """Storage API: abort a transaction."""
@@ -1473,10 +1474,11 @@ class ClientStorage(object):
             if oid == self._load_oid:
                 self._load_status = 0
             self._cache.invalidate(oid, tid)
-        self._cache.setLastTid(tid)
 
         if self._db is not None:
             self._db.invalidate(tid, oids)
+
+        self._cache.setLastTid(tid)
 
     # The following are for compatibility with protocol version 2.0.0
 

--- a/src/ZEO/ClientStorage.py
+++ b/src/ZEO/ClientStorage.py
@@ -1388,6 +1388,14 @@ class ClientStorage(object):
         for oid, tid in self._cache.contents():
             server.verify(oid, tid)
         server.endZeoVerify()
+
+        if server_tid > self._cache.getLastTid():
+            # We verified the cache, and got no new invalidations
+            # while doing so.  The records in the cache are valid,
+            # in that invalid current records were invalidated,
+            # but the last tid is wrong.  Let's fix it:
+            self._cache.setLastTid(server_tid)
+
         return "full verification"
 
     def invalidateVerify(self, oid):

--- a/src/ZEO/ClientStorage.py
+++ b/src/ZEO/ClientStorage.py
@@ -1390,12 +1390,13 @@ class ClientStorage(object):
             server.verify(oid, tid)
         server.endZeoVerify()
 
-        if server_tid > self._cache.getLastTid():
-            # We verified the cache, and got no new invalidations
-            # while doing so.  The records in the cache are valid,
-            # in that invalid current records were invalidated,
-            # but the last tid is wrong.  Let's fix it:
-            self._cache.setLastTid(server_tid)
+        with self._lock:
+            if server_tid > self._cache.getLastTid():
+                # We verified the cache, and got no new invalidations
+                # while doing so.  The records in the cache are valid,
+                # in that invalid current records were invalidated,
+                # but the last tid is wrong.  Let's fix it:
+                self._cache.setLastTid(server_tid)
 
         return "full verification"
 

--- a/src/ZEO/tests/testZEO.py
+++ b/src/ZEO/tests/testZEO.py
@@ -1468,9 +1468,9 @@ But, if we abort, we'll get up to date data and we'll see the changes.
     >>> sorted(conn2.root.x.items())
     [('x', 1), ('y', 1)]
 
+    >>> conn2.close()
     >>> cs.close()
     >>> conn1.close()
-
     """
 
 


### PR DESCRIPTION
These few changes make ZEO tests pass with both ZODB master and the no-more-load branch.

These changes are fixes and reflect the greater importance, now, of ``lastTransaction``.