### PR TITLE
Simplify server vote error handling

### DIFF
--- a/src/ZEO/StorageServer.py
+++ b/src/ZEO/StorageServer.py
@@ -84,7 +84,7 @@ class ZEOStorage:
     blob_tempfile = None
     log_label = 'unconnected'
     locked = False             # Don't have storage lock
-    verifying = store_failed = 0
+    verifying = 0
 
     def __init__(self, server, read_only=0):
         self.server = server
@@ -338,7 +338,6 @@ class ZEOStorage:
         self.blob_log = []
         self.tid = tid
         self.status = status
-        self.store_failed = 0
         self.stats.active_txns += 1
 
         # Assign the transaction attribute last. This is so we don't
@@ -426,29 +425,30 @@ class ZEOStorage:
                     self.storage.tpc_begin(self.transaction)
 
                 for op, args in self.txnlog:
-                    if not getattr(self, op)(*args):
-                        break
+                    getattr(self, op)(*args)
 
 
                 # Blob support
-                while self.blob_log and not self.store_failed:
+                while self.blob_log:
                     oid, oldserial, data, blobfilename = self.blob_log.pop()
                     self._store(oid, oldserial, data, blobfilename)
 
-                if not self.store_failed:
-                    # Only call tpc_vote of no store call failed,
-                    # otherwise the serialnos() call will deliver an
-                    # exception that will be handled by the client in
-                    # its tpc_vote() method.
-                    serials = self.storage.tpc_vote(self.transaction)
-                    if serials:
-                        self.serials.extend(serials)
+                serials = self.storage.tpc_vote(self.transaction)
+                if serials:
+                    self.serials.extend(serials)
 
                 self.connection.async('serialnos', self.serials)
 
-            except Exception:
+            except Exception as err:
                 self.storage.tpc_abort(self.transaction)
                 self._clear_transaction()
+
+                if isinstance(err, ConflictError):
+                    self.stats.conflicts += 1
+                    self.log("conflict error %s" % err, BLATHER)
+                if not isinstance(err, TransactionError):
+                    logger.exception("While voting")
+
                 if delay is not None:
                     delay.error(sys.exc_info())
                 else:
@@ -549,120 +549,44 @@ class ZEOStorage:
         self._check_tid(tid, exc=StorageTransactionError)
         self.txnlog.undo(trans_id)
 
-    def _op_error(self, oid, err, op):
-        self.store_failed = 1
-        if isinstance(err, ConflictError):
-            self.stats.conflicts += 1
-            self.log("conflict error oid=%s msg=%s" %
-                     (oid_repr(oid), str(err)), BLATHER)
-        if not isinstance(err, TransactionError):
-            # Unexpected errors are logged and passed to the client
-            self.log("%s error: %s, %s" % ((op,)+ sys.exc_info()[:2]),
-                     logging.ERROR, exc_info=True)
-        err = self._marshal_error(err)
-        # The exception is reported back as newserial for this oid
-        self.serials.append((oid, err))
-
     def _delete(self, oid, serial):
-        err = None
-        try:
-            self.storage.deleteObject(oid, serial, self.transaction)
-        except (SystemExit, KeyboardInterrupt):
-            raise
-        except Exception as e:
-            err = e
-            self._op_error(oid, err, 'delete')
-
-        return err is None
+        self.storage.deleteObject(oid, serial, self.transaction)
 
     def _checkread(self, oid, serial):
-        err = None
-        try:
-            self.storage.checkCurrentSerialInTransaction(
-                oid, serial, self.transaction)
-        except (SystemExit, KeyboardInterrupt):
-            raise
-        except Exception as e:
-            err = e
-            self._op_error(oid, err, 'checkCurrentSerialInTransaction')
-
-        return err is None
+        self.storage.checkCurrentSerialInTransaction(
+            oid, serial, self.transaction)
 
     def _store(self, oid, serial, data, blobfile=None):
-        err = None
-        try:
-            if blobfile is None:
-                newserial = self.storage.store(
-                    oid, serial, data, '', self.transaction)
-            else:
-                newserial = self.storage.storeBlob(
-                    oid, serial, data, blobfile, '', self.transaction)
-        except (SystemExit, KeyboardInterrupt):
-            raise
-        except Exception as error:
-            self._op_error(oid, error, 'store')
-            err = error
+        if blobfile is None:
+            newserial = self.storage.store(
+                oid, serial, data, '', self.transaction)
         else:
-            if serial != b"\0\0\0\0\0\0\0\0":
-                self.invalidated.append(oid)
+            newserial = self.storage.storeBlob(
+                oid, serial, data, blobfile, '', self.transaction)
 
-            if isinstance(newserial, bytes):
-                newserial = [(oid, newserial)]
+        if serial != b"\0\0\0\0\0\0\0\0":
+            self.invalidated.append(oid)
 
-            for oid, s in newserial or ():
+        if isinstance(newserial, bytes):
+            newserial = [(oid, newserial)]
 
-                if s == ResolvedSerial:
-                    self.stats.conflicts_resolved += 1
-                    self.log("conflict resolved oid=%s"
-                             % oid_repr(oid), BLATHER)
+        for oid, s in newserial or ():
 
-                self.serials.append((oid, s))
+            if s == ResolvedSerial:
+                self.stats.conflicts_resolved += 1
+                self.log("conflict resolved oid=%s"
+                         % oid_repr(oid), BLATHER)
 
-        return err is None
+            self.serials.append((oid, s))
 
     def _restore(self, oid, serial, data, prev_txn):
-        err = None
-        try:
-            self.storage.restore(oid, serial, data, '', prev_txn,
-                                 self.transaction)
-        except (SystemExit, KeyboardInterrupt):
-            raise
-        except Exception as err:
-            self._op_error(oid, err, 'restore')
-
-        return err is None
+        self.storage.restore(oid, serial, data, '', prev_txn,
+                             self.transaction)
 
     def _undo(self, trans_id):
-        err = None
-        try:
-            tid, oids = self.storage.undo(trans_id, self.transaction)
-        except (SystemExit, KeyboardInterrupt):
-            raise
-        except Exception as e:
-            err = e
-            self._op_error(z64, err, 'undo')
-        else:
-            self.invalidated.extend(oids)
-            self.serials.extend((oid, ResolvedSerial) for oid in oids)
-
-        return err is None
-
-    def _marshal_error(self, error):
-        # Try to pickle the exception.  If it can't be pickled,
-        # the RPC response would fail, so use something that can be pickled.
-        if PY3:
-            pickler = Pickler(BytesIO(), 3)
-        else:
-            # The pure-python version requires at least one argument (PyPy)
-            pickler = Pickler(0)
-        pickler.fast = 1
-        try:
-            pickler.dump(error)
-        except:
-            msg = "Couldn't pickle storage exception: %s" % repr(error)
-            self.log(msg, logging.ERROR)
-            error = StorageServerError(msg)
-        return error
+        tid, oids = self.storage.undo(trans_id, self.transaction)
+        self.invalidated.extend(oids)
+        self.serials.extend((oid, ResolvedSerial) for oid in oids)
 
     # IStorageIteration support
 

--- a/src/ZEO/asyncio/server.py
+++ b/src/ZEO/asyncio/server.py
@@ -17,7 +17,7 @@ class ServerProtocol(base.Protocol):
     """asyncio low-level ZEO server interface
     """
 
-    protocols = b'Z4', b'Z5'
+    protocols = (b'Z5', )
 
     name = 'server protocol'
     methods = set(('register', ))
@@ -161,7 +161,7 @@ class Delay:
 
     def error(self, exc_info):
         self.sent = 'error'
-        log("Error raised in delayed method", logging.ERROR, exc_info=exc_info)
+        logger.error("Error raised in delayed method", exc_info=exc_info)
         self.protocol.send_error(self.msgid, exc_info[1])
 
     def __repr__(self):
@@ -198,5 +198,4 @@ class MTDelay(Delay):
 
     def error(self, exc_info):
         self.ready.wait()
-        log("Error raised in delayed method", logging.ERROR, exc_info=exc_info)
         self.protocol.call_soon_threadsafe(Delay.error, self, exc_info)

--- a/src/ZEO/asyncio/tests.py
+++ b/src/ZEO/asyncio/tests.py
@@ -750,7 +750,7 @@ class ServerTests(Base, setupstack.TestCase):
         self.target = protocol.zeo_storage
         if finish:
             self.assertEqual(self.pop(parse=False), best_protocol_version)
-            protocol.data_received(sized(b'Z4'))
+            protocol.data_received(sized(b'Z5'))
         return protocol
 
     message_id = 0
@@ -788,9 +788,9 @@ class ServerTests(Base, setupstack.TestCase):
         self.assertEqual(self.pop(parse=False), best_protocol_version)
 
         # The client sends it's protocol:
-        protocol.data_received(sized(b'Z4'))
+        protocol.data_received(sized(b'Z5'))
 
-        self.assertEqual(protocol.protocol_version, b'Z4')
+        self.assertEqual(protocol.protocol_version, b'Z5')
 
         protocol.zeo_storage.notify_connected.assert_called_once_with(protocol)
 

--- a/src/ZEO/cache.py
+++ b/src/ZEO/cache.py
@@ -33,7 +33,7 @@ import time
 
 import ZODB.fsIndex
 import zc.lockfile
-from ZODB.utils import p64, u64, z64
+from ZODB.utils import p64, u64, z64, RLock
 import six
 from ._compat import PYPY
 
@@ -182,6 +182,8 @@ class ClientCache(object):
         # currentofs.
         self.currentofs = ZEC_HEADER_SIZE
 
+        self._lock = RLock()
+
         # self.f is the open file object.
         # When we're not reusing an existing file, self.f is left None
         # here -- the scan() method must be called then to open the file
@@ -239,9 +241,10 @@ class ClientCache(object):
         return self
 
     def clear(self):
-        self.f.seek(ZEC_HEADER_SIZE)
-        self.f.truncate()
-        self._initfile(ZEC_HEADER_SIZE)
+        with self._lock:
+            self.f.seek(ZEC_HEADER_SIZE)
+            self.f.truncate()
+            self._initfile(ZEC_HEADER_SIZE)
 
     ##
     # Scan the current contents of the cache file, calling `install`
@@ -451,26 +454,28 @@ class ClientCache(object):
     # new tid must be strictly greater than our current idea of the most
     # recent tid.
     def setLastTid(self, tid):
-        if (not tid) or (tid == z64):
-            return
-        if (tid <= self.tid) and self._len:
-            if tid == self.tid:
-                return                  # Be a little forgiving
-            raise ValueError("new last tid (%s) must be greater than "
-                             "previous one (%s)"
-                             % (u64(tid), u64(self.tid)))
-        assert isinstance(tid, bytes) and len(tid) == 8, tid
-        self.tid = tid
-        self.f.seek(len(magic))
-        self.f.write(tid)
-        self.f.flush()
+        with self._lock:
+            if (not tid) or (tid == z64):
+                return
+            if (tid <= self.tid) and self._len:
+                if tid == self.tid:
+                    return                  # Be a little forgiving
+                raise ValueError("new last tid (%s) must be greater than "
+                                 "previous one (%s)"
+                                 % (u64(tid), u64(self.tid)))
+            assert isinstance(tid, bytes) and len(tid) == 8, tid
+            self.tid = tid
+            self.f.seek(len(magic))
+            self.f.write(tid)
+            self.f.flush()
 
     ##
     # Return the last transaction seen by the cache.
     # @return a transaction id
     # @defreturn string, or 8 nulls if no transaction is yet known
     def getLastTid(self):
-        return self.tid
+        with self._lock:
+            return self.tid
 
     ##
     # Return the current data record for oid.
@@ -479,52 +484,54 @@ class ClientCache(object):
     #         in the cache
     # @defreturn 3-tuple: (string, string, string)
     def load(self, oid, before_tid=None):
-        ofs = self.current.get(oid)
-        if ofs is None:
-            self._trace(0x20, oid)
-            return None
-        self.f.seek(ofs)
-        read = self.f.read
-        status = read(1)
-        assert status == b'a', (ofs, self.f.tell(), oid)
-        size, saved_oid, tid, end_tid, lver, ldata = unpack(
-            ">I8s8s8sHI", read(34))
-        assert saved_oid == oid, (ofs, self.f.tell(), oid, saved_oid)
-        assert end_tid == z64, (ofs, self.f.tell(), oid, tid, end_tid)
-        assert lver == 0, "Versions aren't supported"
-
-        if before_tid and tid >= before_tid:
-            return None
-
-        data = read(ldata)
-        assert len(data) == ldata, (ofs, self.f.tell(), oid, len(data), ldata)
-
-        # WARNING: The following assert changes the file position.
-        # We must not depend on this below or we'll fail in optimized mode.
-        assert read(8) == oid, (ofs, self.f.tell(), oid)
-
-        self._n_accesses += 1
-        self._trace(0x22, oid, tid, end_tid, ldata)
-
-        ofsofs = self.currentofs - ofs
-        if ofsofs < 0:
-            ofsofs += self.maxsize
-
-        if (ofsofs > self.rearrange and
-            self.maxsize > 10*len(data) and
-            size > 4):
-            # The record is far back and might get evicted, but it's
-            # valuable, so move it forward.
-
-            # Remove fromn old loc:
-            del self.current[oid]
+        with self._lock:
+            ofs = self.current.get(oid)
+            if ofs is None:
+                self._trace(0x20, oid)
+                return None
             self.f.seek(ofs)
-            self.f.write(b'f'+pack(">I", size))
+            read = self.f.read
+            status = read(1)
+            assert status == b'a', (ofs, self.f.tell(), oid)
+            size, saved_oid, tid, end_tid, lver, ldata = unpack(
+                ">I8s8s8sHI", read(34))
+            assert saved_oid == oid, (ofs, self.f.tell(), oid, saved_oid)
+            assert end_tid == z64, (ofs, self.f.tell(), oid, tid, end_tid)
+            assert lver == 0, "Versions aren't supported"
 
-            # Write to new location:
-            self._store(oid, tid, None, data, size)
+            if before_tid and tid >= before_tid:
+                return None
 
-        return data, tid
+            data = read(ldata)
+            assert len(data) == ldata, (
+                ofs, self.f.tell(), oid, len(data), ldata)
+
+            # WARNING: The following assert changes the file position.
+            # We must not depend on this below or we'll fail in optimized mode.
+            assert read(8) == oid, (ofs, self.f.tell(), oid)
+
+            self._n_accesses += 1
+            self._trace(0x22, oid, tid, end_tid, ldata)
+
+            ofsofs = self.currentofs - ofs
+            if ofsofs < 0:
+                ofsofs += self.maxsize
+
+            if (ofsofs > self.rearrange and
+                self.maxsize > 10*len(data) and
+                size > 4):
+                # The record is far back and might get evicted, but it's
+                # valuable, so move it forward.
+
+                # Remove fromn old loc:
+                del self.current[oid]
+                self.f.seek(ofs)
+                self.f.write(b'f'+pack(">I", size))
+
+                # Write to new location:
+                self._store(oid, tid, None, data, size)
+
+            return data, tid
 
     ##
     # Return a non-current revision of oid that was current before tid.
@@ -533,54 +540,56 @@ class ClientCache(object):
     # @return data record, serial number, start tid, and end tid
     # @defreturn 4-tuple: (string, string, string, string)
     def loadBefore(self, oid, before_tid):
-        noncurrent_for_oid = self.noncurrent.get(u64(oid))
-        if noncurrent_for_oid is None:
-            result = self.load(oid, before_tid)
-            if result:
-                return result[0], result[1], None
-            else:
-                self._trace(0x24, oid, "", before_tid)
-                return result
+        with self._lock:
+            noncurrent_for_oid = self.noncurrent.get(u64(oid))
+            if noncurrent_for_oid is None:
+                result = self.load(oid, before_tid)
+                if result:
+                    return result[0], result[1], None
+                else:
+                    self._trace(0x24, oid, "", before_tid)
+                    return result
 
-        items = noncurrent_for_oid.items(None, u64(before_tid)-1)
-        if not items:
-            result = self.load(oid, before_tid)
-            if result:
-                return result[0], result[1], None
-            else:
-                self._trace(0x24, oid, "", before_tid)
-                return result
+            items = noncurrent_for_oid.items(None, u64(before_tid)-1)
+            if not items:
+                result = self.load(oid, before_tid)
+                if result:
+                    return result[0], result[1], None
+                else:
+                    self._trace(0x24, oid, "", before_tid)
+                    return result
 
-        tid, ofs = items[-1]
+            tid, ofs = items[-1]
 
-        self.f.seek(ofs)
-        read = self.f.read
-        status = read(1)
-        assert status == b'a', (ofs, self.f.tell(), oid, before_tid)
-        size, saved_oid, saved_tid, end_tid, lver, ldata = unpack(
-            ">I8s8s8sHI", read(34))
-        assert saved_oid == oid, (ofs, self.f.tell(), oid, saved_oid)
-        assert saved_tid == p64(tid), (ofs, self.f.tell(), oid, saved_tid, tid)
-        assert end_tid != z64, (ofs, self.f.tell(), oid)
-        assert lver == 0, "Versions aren't supported"
-        data = read(ldata)
-        assert len(data) == ldata, (ofs, self.f.tell())
+            self.f.seek(ofs)
+            read = self.f.read
+            status = read(1)
+            assert status == b'a', (ofs, self.f.tell(), oid, before_tid)
+            size, saved_oid, saved_tid, end_tid, lver, ldata = unpack(
+                ">I8s8s8sHI", read(34))
+            assert saved_oid == oid, (ofs, self.f.tell(), oid, saved_oid)
+            assert saved_tid == p64(tid), (
+                ofs, self.f.tell(), oid, saved_tid, tid)
+            assert end_tid != z64, (ofs, self.f.tell(), oid)
+            assert lver == 0, "Versions aren't supported"
+            data = read(ldata)
+            assert len(data) == ldata, (ofs, self.f.tell())
 
-        # WARNING: The following assert changes the file position.
-        # We must not depend on this below or we'll fail in optimized mode.
-        assert read(8) == oid, (ofs, self.f.tell(), oid)
+            # WARNING: The following assert changes the file position.
+            # We must not depend on this below or we'll fail in optimized mode.
+            assert read(8) == oid, (ofs, self.f.tell(), oid)
 
-        if end_tid < before_tid:
-            result = self.load(oid, before_tid)
-            if result:
-                return result[0], result[1], None
-            else:
-                self._trace(0x24, oid, "", before_tid)
-                return result
+            if end_tid < before_tid:
+                result = self.load(oid, before_tid)
+                if result:
+                    return result[0], result[1], None
+                else:
+                    self._trace(0x24, oid, "", before_tid)
+                    return result
 
-        self._n_accesses += 1
-        self._trace(0x26, oid, "", saved_tid)
-        return data, saved_tid, end_tid
+            self._n_accesses += 1
+            self._trace(0x26, oid, "", saved_tid)
+            return data, saved_tid, end_tid
 
     ##
     # Store a new data record in the cache.
@@ -591,45 +600,48 @@ class ClientCache(object):
     #                current.
     # @param data the actual data
     def store(self, oid, start_tid, end_tid, data):
-        seek = self.f.seek
-        if end_tid is None:
-            ofs = self.current.get(oid)
-            if ofs:
-                seek(ofs)
-                read = self.f.read
-                status = read(1)
-                assert status == b'a', (ofs, self.f.tell(), oid)
-                size, saved_oid, saved_tid, end_tid = unpack(
-                    ">I8s8s8s", read(28))
-                assert saved_oid == oid, (ofs, self.f.tell(), oid, saved_oid)
-                assert end_tid == z64, (ofs, self.f.tell(), oid)
-                if saved_tid == start_tid:
+        with self._lock:
+            seek = self.f.seek
+            if end_tid is None:
+                ofs = self.current.get(oid)
+                if ofs:
+                    seek(ofs)
+                    read = self.f.read
+                    status = read(1)
+                    assert status == b'a', (ofs, self.f.tell(), oid)
+                    size, saved_oid, saved_tid, end_tid = unpack(
+                        ">I8s8s8s", read(28))
+                    assert saved_oid == oid, (
+                        ofs, self.f.tell(), oid, saved_oid)
+                    assert end_tid == z64, (ofs, self.f.tell(), oid)
+                    if saved_tid == start_tid:
+                        return
+                    raise ValueError("already have current data for oid")
+            else:
+                noncurrent_for_oid = self.noncurrent.get(u64(oid))
+                if noncurrent_for_oid and (
+                    u64(start_tid) in noncurrent_for_oid):
                     return
-                raise ValueError("already have current data for oid")
-        else:
-            noncurrent_for_oid = self.noncurrent.get(u64(oid))
-            if noncurrent_for_oid and (u64(start_tid) in noncurrent_for_oid):
+
+            size = allocated_record_overhead + len(data)
+
+            # A number of cache simulation experiments all concluded that the
+            # 2nd-level ZEO cache got a much higher hit rate if "very large"
+            # objects simply weren't cached.  For now, we ignore the request
+            # only if the entire cache file is too small to hold the object.
+            if size >= min(max_block_size, self.maxsize - ZEC_HEADER_SIZE):
                 return
 
-        size = allocated_record_overhead + len(data)
+            self._n_adds += 1
+            self._n_added_bytes += size
+            self._len += 1
 
-        # A number of cache simulation experiments all concluded that the
-        # 2nd-level ZEO cache got a much higher hit rate if "very large"
-        # objects simply weren't cached.  For now, we ignore the request
-        # only if the entire cache file is too small to hold the object.
-        if size >= min(max_block_size, self.maxsize - ZEC_HEADER_SIZE):
-            return
+            self._store(oid, start_tid, end_tid, data, size)
 
-        self._n_adds += 1
-        self._n_added_bytes += size
-        self._len += 1
-
-        self._store(oid, start_tid, end_tid, data, size)
-
-        if end_tid:
-            self._trace(0x54, oid, start_tid, end_tid, dlen=len(data))
-        else:
-            self._trace(0x52, oid, start_tid, dlen=len(data))
+            if end_tid:
+                self._trace(0x54, oid, start_tid, end_tid, dlen=len(data))
+            else:
+                self._trace(0x52, oid, start_tid, dlen=len(data))
 
     def _store(self, oid, start_tid, end_tid, data, size):
         # Low-level store used by store and load
@@ -696,35 +708,37 @@ class ClientCache(object):
     # - tid the id of the transaction that wrote a new revision of oid,
     #        or None to forget all cached info about oid.
     def invalidate(self, oid, tid):
-        ofs = self.current.get(oid)
-        if ofs is None:
-            # 0x10 == invalidate (miss)
-            self._trace(0x10, oid, tid)
-            return
-
-        self.f.seek(ofs)
-        read = self.f.read
-        status = read(1)
-        assert status == b'a', (ofs, self.f.tell(), oid)
-        size, saved_oid, saved_tid, end_tid = unpack(">I8s8s8s", read(28))
-        assert saved_oid == oid, (ofs, self.f.tell(), oid, saved_oid)
-        assert end_tid == z64, (ofs, self.f.tell(), oid)
-        del self.current[oid]
-        if tid is None:
-            self.f.seek(ofs)
-            self.f.write(b'f'+pack(">I", size))
-            # 0x1E = invalidate (hit, discarding current or non-current)
-            self._trace(0x1E, oid, tid)
-            self._len -= 1
-        else:
-            if tid == saved_tid:
-                logger.warning("Ignoring invalidation with same tid as current")
+        with self._lock:
+            ofs = self.current.get(oid)
+            if ofs is None:
+                # 0x10 == invalidate (miss)
+                self._trace(0x10, oid, tid)
                 return
-            self.f.seek(ofs+21)
-            self.f.write(tid)
-            self._set_noncurrent(oid, saved_tid, ofs)
-            # 0x1C = invalidate (hit, saving non-current)
-            self._trace(0x1C, oid, tid)
+
+            self.f.seek(ofs)
+            read = self.f.read
+            status = read(1)
+            assert status == b'a', (ofs, self.f.tell(), oid)
+            size, saved_oid, saved_tid, end_tid = unpack(">I8s8s8s", read(28))
+            assert saved_oid == oid, (ofs, self.f.tell(), oid, saved_oid)
+            assert end_tid == z64, (ofs, self.f.tell(), oid)
+            del self.current[oid]
+            if tid is None:
+                self.f.seek(ofs)
+                self.f.write(b'f'+pack(">I", size))
+                # 0x1E = invalidate (hit, discarding current or non-current)
+                self._trace(0x1E, oid, tid)
+                self._len -= 1
+            else:
+                if tid == saved_tid:
+                    logger.warning(
+                        "Ignoring invalidation with same tid as current")
+                    return
+                self.f.seek(ofs+21)
+                self.f.write(tid)
+                self._set_noncurrent(oid, saved_tid, ofs)
+                # 0x1C = invalidate (hit, saving non-current)
+                self._trace(0x1C, oid, tid)
 
     ##
     # Generates (oid, serial) oairs for all objects in the

--- a/src/ZEO/interfaces.py
+++ b/src/ZEO/interfaces.py
@@ -24,8 +24,7 @@ class StaleCache(object):
 class IClientCache(zope.interface.Interface):
     """Client cache interface.
 
-    Note that caches need not be thread safe, fpr the most part,
-    except for getLastTid, which may be called from multiple threads.
+    Note that caches need to be thread safe.
     """
 
     def close():

--- a/src/ZEO/tests/forker.py
+++ b/src/ZEO/tests/forker.py
@@ -94,6 +94,10 @@ def runner(config, qin, qout, timeout=None,
         import ZEO.asyncio.server
         old_protocol = ZEO.asyncio.server.best_protocol_version
         ZEO.asyncio.server.best_protocol_version = protocol
+        old_protocols = ZEO.asyncio.server.ServerProtocol.protocols
+        ZEO.asyncio.server.ServerProtocol.protocols = tuple(sorted(
+            set(old_protocols) | set([protocol])
+            ))
 
     try:
         import ZEO.runzeo, threading
@@ -144,8 +148,8 @@ def runner(config, qin, qout, timeout=None,
 
     finally:
         if old_protocol:
-            ZEO.asyncio.server.best_protocol_version = protocol
-
+            ZEO.asyncio.server.best_protocol_version = old_protocol
+            ZEO.asyncio.server.ServerProtocol.protocols = old_protocols
 
 def stop_runner(thread, config, qin, qout, stop_timeout=9, pid=None):
     qin.put('stop')

--- a/src/ZEO/tests/protocols.test
+++ b/src/ZEO/tests/protocols.test
@@ -5,7 +5,7 @@ A full test of all protocols isn't practical.  But we'll do a limited
 test that at least the current and previous protocols are supported in
 both directions.
 
-Let's start a Z309 server
+Let's start a Z4 server
 
     >>> storage_conf = '''
     ... <blobstorage>
@@ -94,82 +94,85 @@ A current client should be able to connect to a old server:
     >>> zope.testing.setupstack.rmtree('blobs')
     >>> zope.testing.setupstack.rmtree('server-blobs')
 
-And the other way around:
+#############################################################################
+# Note that the ZEO 5.0 server only supports clients that use the Z5 protocol
 
-    >>> addr, _ = start_server(storage_conf, dict(invalidation_queue_size=5))
+# And the other way around:
 
-Note that we'll have to pull some hijinks:
+#     >>> addr, _ = start_server(storage_conf, dict(invalidation_queue_size=5))
 
-    >>> import ZEO.asyncio.client
-    >>> old_protocols = ZEO.asyncio.client.Protocol.protocols
-    >>> ZEO.asyncio.client.Protocol.protocols = [b'Z4']
+# Note that we'll have to pull some hijinks:
 
-    >>> db = ZEO.DB(addr, client='client', blob_dir='blobs')
-    >>> db.storage.protocol_version
-    b'Z4'
-    >>> wait_connected(db.storage)
-    >>> conn = db.open()
-    >>> conn.root().x = 0
-    >>> transaction.commit()
-    >>> len(db.history(conn.root()._p_oid, 99))
-    2
+#     >>> import ZEO.asyncio.client
+#     >>> old_protocols = ZEO.asyncio.client.Protocol.protocols
+#     >>> ZEO.asyncio.client.Protocol.protocols = [b'Z4']
 
-    >>> conn.root()['blob1'] = ZODB.blob.Blob()
-    >>> with conn.root()['blob1'].open('w') as f:
-    ...    r = f.write(b'blob data 1')
-    >>> transaction.commit()
+#     >>> db = ZEO.DB(addr, client='client', blob_dir='blobs')
+#     >>> db.storage.protocol_version
+#     b'Z4'
+#     >>> wait_connected(db.storage)
+#     >>> conn = db.open()
+#     >>> conn.root().x = 0
+#     >>> transaction.commit()
+#     >>> len(db.history(conn.root()._p_oid, 99))
+#     2
 
-    >>> db2 = ZEO.DB(addr, blob_dir='server-blobs', shared_blob_dir=True)
-    >>> wait_connected(db2.storage)
-    >>> conn2 = db2.open()
-    >>> for i in range(5):
-    ...     conn2.root().x += 1
-    ...     transaction.commit()
-    >>> conn2.root()['blob2'] = ZODB.blob.Blob()
-    >>> with conn2.root()['blob2'].open('w') as f:
-    ...    r = f.write(b'blob data 2')
-    >>> transaction.commit()
+#     >>> conn.root()['blob1'] = ZODB.blob.Blob()
+#     >>> with conn.root()['blob1'].open('w') as f:
+#     ...    r = f.write(b'blob data 1')
+#     >>> transaction.commit()
+
+#     >>> db2 = ZEO.DB(addr, blob_dir='server-blobs', shared_blob_dir=True)
+#     >>> wait_connected(db2.storage)
+#     >>> conn2 = db2.open()
+#     >>> for i in range(5):
+#     ...     conn2.root().x += 1
+#     ...     transaction.commit()
+#     >>> conn2.root()['blob2'] = ZODB.blob.Blob()
+#     >>> with conn2.root()['blob2'].open('w') as f:
+#     ...    r = f.write(b'blob data 2')
+#     >>> transaction.commit()
 
 
-    >>> @wait_until()
-    ... def x_to_be_5():
-    ...     conn.sync()
-    ...     return conn.root().x == 5
+#     >>> @wait_until()
+#     ... def x_to_be_5():
+#     ...     conn.sync()
+#     ...     return conn.root().x == 5
 
-    >>> db.close()
+#     >>> db.close()
 
-    >>> for i in range(2):
-    ...     conn2.root().x += 1
-    ...     transaction.commit()
+#     >>> for i in range(2):
+#     ...     conn2.root().x += 1
+#     ...     transaction.commit()
 
-    >>> db = ZEO.DB(addr, client='client', blob_dir='blobs')
-    >>> wait_connected(db.storage)
-    >>> conn = db.open()
-    >>> conn.root().x
-    7
+#     >>> db = ZEO.DB(addr, client='client', blob_dir='blobs')
+#     >>> wait_connected(db.storage)
+#     >>> conn = db.open()
+#     >>> conn.root().x
+#     7
 
-    >>> db.close()
+#     >>> db.close()
 
-    >>> for i in range(10):
-    ...     conn2.root().x += 1
-    ...     transaction.commit()
+#     >>> for i in range(10):
+#     ...     conn2.root().x += 1
+#     ...     transaction.commit()
 
-    >>> db = ZEO.DB(addr, client='client', blob_dir='blobs')
-    >>> wait_connected(db.storage)
-    >>> conn = db.open()
-    >>> conn.root().x
-    17
+#     >>> db = ZEO.DB(addr, client='client', blob_dir='blobs')
+#     >>> wait_connected(db.storage)
+#     >>> conn = db.open()
+#     >>> conn.root().x
+#     17
 
-    >>> with conn.root()['blob1'].open() as f:
-    ...    f.read()
-    b'blob data 1'
-    >>> with conn.root()['blob2'].open() as f:
-    ...    f.read()
-    b'blob data 2'
+#     >>> with conn.root()['blob1'].open() as f:
+#     ...    f.read()
+#     b'blob data 1'
+#     >>> with conn.root()['blob2'].open() as f:
+#     ...    f.read()
+#     b'blob data 2'
 
-    >>> db2.close()
-    >>> db.close()
+#     >>> db2.close()
+#     >>> db.close()
 
-Undo the hijinks:
+# Undo the hijinks:
 
-    >>> ZEO.asyncio.client.Protocol.protocols = old_protocols
+#     >>> ZEO.asyncio.client.Protocol.protocols = old_protocols

--- a/src/ZEO/tests/testZEO2.py
+++ b/src/ZEO/tests/testZEO2.py
@@ -78,6 +78,8 @@ will conflict. It will be blocked at the vote call.
     >>> class Sender:
     ...     def send_reply(self, id, reply):
     ...         print('reply', id, reply)
+    ...     def send_error(self, id, err):
+    ...         print('error', id, err)
     >>> delay.set_sender(1, Sender())
 
     >>> logger = logging.getLogger('ZEO')
@@ -87,13 +89,20 @@ will conflict. It will be blocked at the vote call.
 
 Now, when we abort the transaction for the first client. The second
 client will be restarted.  It will get a conflict error, that is
-handled correctly:
+raised to the client:
 
     >>> zs1.tpc_abort('0') # doctest: +ELLIPSIS
-    reply 1 None
+    Error raised in delayed method
+    Traceback (most recent call last):
+    ...
+    ZODB.POSException.ConflictError: ...
+    error 1 database conflict error ...
 
-    >>> fs.tpc_transaction() is not None
+The transaction is aborted by the server:
+
+    >>> fs.tpc_transaction() is None
     True
+
     >>> zs2.connected
     True
 
@@ -116,7 +125,7 @@ And an initial client.
 
     >>> zs1 = ZEO.tests.servertesting.client(server, 1)
     >>> zs1.tpc_begin('0', '', '', {})
-    >>> zs1.storea(ZODB.utils.p64(99), ZODB.utils.z64, 'x', '0')
+    >>> zs1.storea(ZODB.utils.p64(99), ZODB.utils.z64, b'x', '0')
 
 Intentionally break zs1:
 
@@ -135,7 +144,7 @@ We can start another client and get the storage lock.
 
     >>> zs1 = ZEO.tests.servertesting.client(server, 1)
     >>> zs1.tpc_begin('1', '', '', {})
-    >>> zs1.storea(ZODB.utils.p64(99), ZODB.utils.z64, 'x', '1')
+    >>> zs1.storea(ZODB.utils.p64(99), ZODB.utils.z64, b'x', '1')
     >>> _ = zs1.vote('1') # doctest: +ELLIPSIS
 
     >>> zs1.tpc_finish('1').set_sender(0, zs1.connection)


### PR DESCRIPTION
ZEO's vote error handling was extremely and weirdly complicated.
There's a hysterical explanation: Originally, the ZEO protocol was
synchronous and mirrored the storage API. That was too slow, so store
was made asynchronous.  But then there was no way to return new
serials or errors, so we added a serialnos client API that the server called
during TPC. This was used both to send serials and errors to the client.  Later, tpc_vote
was added, which is a synchronous method. That would have been an
excellent opportunity to fix this, but noooooooooo.

I'd like the server vote logic to get simpler, and we also want to get rid
of serialnos, as it makes it hard to commit multiple transactions at
once on the client.  We can't get rid of serialnos now, because the
client needs to work with old servers.

Of course, nothing is easy. There was a special edge case where if the
client saw an unhandled conflict error, it would invalidate it's cache
for that object, allowing it to eventually recover when caches had
missed invalidations. This required a change to ClientStorage, which
meant that the server wouldn't work with older ZEO versions, which
meant that the server could only support protocol Z5, which in tern
affected protocol-negotiation tests....
