### PR TITLE
Fix tracing of loadBefore with empty tids on Py3.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+4.2.2 (unreleased)
+------------------
+
+- Fix ZEO cache tracing on Python 3.
+
 4.2.1 (2016-06-30)
 ------------------
 

--- a/src/ZEO/cache.py
+++ b/src/ZEO/cache.py
@@ -557,7 +557,7 @@ class ClientCache(object):
             if result:
                 return result[0], result[1], None
             else:
-                self._trace(0x24, oid, "", before_tid)
+                self._trace(0x24, oid, b"", before_tid)
                 return result
 
         items = noncurrent_for_oid.items(None, u64(before_tid)-1)
@@ -566,7 +566,7 @@ class ClientCache(object):
             if result:
                 return result[0], result[1], None
             else:
-                self._trace(0x24, oid, "", before_tid)
+                self._trace(0x24, oid, b"", before_tid)
                 return result
 
         tid, ofs = items[-1]
@@ -593,11 +593,11 @@ class ClientCache(object):
             if result:
                 return result[0], result[1], None
             else:
-                self._trace(0x24, oid, "", before_tid)
+                self._trace(0x24, oid, b"", before_tid)
                 return result
 
         self._n_accesses += 1
-        self._trace(0x26, oid, "", saved_tid)
+        self._trace(0x26, oid, b"", saved_tid)
         return data, saved_tid, end_tid
 
     ##


### PR DESCRIPTION
This code path was using a constant `""` for the `tid`, which is a `str` on Py3, not bytes, leading to:
```python
Traceback (most recent call last):
...
  File "//zodbshootout-main/src/zodbshootout/_runner.py", line 148, in make_factory
    _db = db_conf.open()
  File "//site-packages/ZODB/config.py", line 130, in open
    **options)
  File "///site-packages/ZODB/DB.py", line 443, in __init__
    temp_storage.load(z64, '')
  File "//ZEO/src/ZEO/ClientStorage.py", line 825, in load
    result = self.loadBefore(oid, m64)
  File "//ZEO/src/ZEO/ClientStorage.py", line 834, in loadBefore
    result = self._cache.loadBefore(oid, tid)
  File "//ZEO/src/ZEO/cache.py", line 139, in _locked_wrapper
    return func(inst, *args, **kwargs)
  File "//ZEO/src/ZEO/cache.py", line 560, in loadBefore
    self._trace(0x24, oid, "", before_tid)
  File "//ZEO/src/ZEO/cache.py", line 826, in _trace
    int(now()), encoded, len(oid), tid, end_tid) + oid,
struct.error: argument for 's' must be a bytes object
```

Unfortunately, this particular combo (tracing enabled + loadBefore) doesn't seem to be covered by existing tests, at least not yet.