### PR TITLE
Added the ability to pass credentials when creating client storages.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,20 @@
 Changelog
 =========
 
+- Added the ability to pass credentials when creating client storages.
+
+  This is experimental in that passing credentials will cause
+  connections to an ordinary ZEO server to fail, but it facilitates
+  experimentation with custom ZEO servers. Doing this with custom ZEO
+  clients would have been awkward due to the many levels of
+  composition involved.
+
+  In the future, we expect to support server security plugins that
+  consume credentials for authentication (typically over SSL).
+
+  Note that credentials are opaque to ZEO. They can be any object with
+  a true value.  The client mearly passes them to the server, which
+  will someday pass them to a plugin.
 
 5.0.0a1 (2016-07-21)
 --------------------

--- a/src/ZEO/ClientStorage.py
+++ b/src/ZEO/ClientStorage.py
@@ -99,6 +99,7 @@ class ClientStorage(ZODB.ConflictResolution.ConflictResolvingStorage):
                  wait=True,
                  drop_cache_rather_verify=True,
                  username=None, password=None, realm=None,
+                 credentials=None,
                  # For tests:
                  _client_factory=ZEO.asyncio.client.ClientThread,
                  ):
@@ -261,6 +262,7 @@ class ClientStorage(ZODB.ConflictResolution.ConflictResolvingStorage):
             ZEO.asyncio.client.Fallback if read_only_fallback else read_only,
             wait_timeout or 30,
             ssl = ssl, ssl_server_hostname=ssl_server_hostname,
+            credentials=credentials,
             )
         self._call = self._server.call
         self._async = self._server.async

--- a/src/ZEO/tests/test_client_credentials.py
+++ b/src/ZEO/tests/test_client_credentials.py
@@ -1,0 +1,56 @@
+"""Clients can pass credentials to a server.
+
+This is an experimental feature to enable server authentication and
+authorization.
+"""
+from zope.testing import setupstack
+import unittest
+
+import ZEO.StorageServer
+
+class ClientAuthTests(setupstack.TestCase):
+
+    def setUp(self):
+        self.setUpDirectory()
+        self.__register = ZEO.StorageServer.ZEOStorage.register
+
+    def tearDown(self):
+        ZEO.StorageServer.ZEOStorage.register = self.__register
+
+    def test_passing_credentials(self):
+
+        # First, we'll temporarily swap the storage server register
+        # method with one that let's is see credentials that were passed:
+
+        creds_log = []
+
+        def register(zs, storage_id, read_only, credentials=self):
+            creds_log.append(credentials)
+            return self.__register(zs, storage_id, read_only)
+
+        ZEO.StorageServer.ZEOStorage.register = register
+
+        # Now start an in process server
+        addr, stop = ZEO.server()
+
+        # If we connect, without providing credentials, then no
+        # credentials will be passed to register:
+
+        client = ZEO.client(addr)
+
+        self.assertEqual(creds_log, [self])
+        client.close()
+        creds_log.pop()
+
+        # But if we pass credentials, they'll be passed to register:
+        creds = dict(user='me', password='123')
+        client = ZEO.client(addr, credentials=creds)
+        self.assertEqual(creds_log, [creds])
+        client.close()
+
+        stop()
+
+
+def test_suite():
+    return unittest.makeSuite(ClientAuthTests)
+


### PR DESCRIPTION
This is experimental in that passing credentials will cause
connections to an ordinary ZEO server to fail, but it facilitates
experimentation with custom ZEO servers. Doing this with custom ZEO
clients would have been awkward due to the many levels of
composition involved.

In the future, we expect to support server security plugins that
consume credentials for authentication (typically over SSL).

Note that credentials are opaque to ZEO. They can be any object with
a true value.  The client mearly passes them to the server, which
will someday pass them to a plugin.