### PR TITLE
The ZEO server register method now returns the storage last transaction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+- The ZEO server register method now returns the storage last
+  transaction, allowing the client to avoid an extra round trip during
+  cache verification.
+
 - Fixed bugs in using the ZEO 5 client with ZEO 4 servers.
 
 5.0.0a2 (2016-07-30)

--- a/src/ZEO/StorageServer.py
+++ b/src/ZEO/StorageServer.py
@@ -222,6 +222,8 @@ class ZEOStorage:
         self.stats = self.server.register_connection(storage_id, self)
         self.lock_manager = self.server.lock_managers[storage_id]
 
+        return self.lastTransaction()
+
     def get_info(self):
         storage = self.storage
 

--- a/src/ZEO/tests/testZEO.py
+++ b/src/ZEO/tests/testZEO.py
@@ -831,7 +831,8 @@ Now we'll open a storage server on the data, simulating a restart:
     >>> sv = StorageServer(None, dict(fs=fs))
     >>> s = ZEOStorage(sv, sv.read_only)
     >>> s.notify_connected(FauxConn())
-    >>> s.register('fs', False)
+    >>> s.register('fs', False) == fs.lastTransaction()
+    True
 
 If we ask for the last transaction, we should get the last transaction
 we saved:


### PR DESCRIPTION
This allows the client to avoid an extra round trip during cache verification.

This fixes #55.