### PR TITLE
Client disconnect errors are now transient errors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: python
 sudo: false
+cache:
+  pip
+  directories:
+    - eggs
 matrix:
     include:
         - os: linux
@@ -24,9 +28,8 @@ matrix:
           python: 3.5
           env: ZEO4_SERVER=1
 install:
-    - pip install -U setuptools
-    - python bootstrap.py
-    - bin/buildout
+    - pip install -U zc.buildout
+    - buildout
 script:
     - bin/test -v1j99
 notifications:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+- Client disconnect errors are now transient errors.  When
+  applications retry jobs that raise transient errors, jobs (e.g. web
+  requests) with disconnect errors will be retried. Together with
+  blocking synchronous ZEO server calls for a limited time while
+  disconnected, this change should allow brief disconnections due to
+  server restart to avoid generating client-visible errors (e.g. 500
+  web responses).
+
 - Fixed bugs in using the ZEO 5 client with ZEO 4 servers.
 
 5.0.0a2 (2016-07-30)

--- a/src/ZEO/Exceptions.py
+++ b/src/ZEO/Exceptions.py
@@ -13,19 +13,26 @@
 ##############################################################################
 """Exceptions for ZEO."""
 
+import transaction.interfaces
+
 from ZODB.POSException import StorageError
 
 class ClientStorageError(StorageError):
-    """An error occurred in the ZEO Client Storage."""
+    """An error occurred in the ZEO Client Storage.
+    """
 
 class UnrecognizedResult(ClientStorageError):
-    """A server call returned an unrecognized result."""
+    """A server call returned an unrecognized result.
+    """
 
-class ClientDisconnected(ClientStorageError):
-    """The database storage is disconnected from the storage."""
+class ClientDisconnected(ClientStorageError,
+                         transaction.interfaces.TransientError):
+    """The database storage is disconnected from the storage.
+    """
 
 class AuthError(StorageError):
-    """The client provided invalid authentication credentials."""
+    """The client provided invalid authentication credentials.
+    """
 
 class ProtocolError(ClientStorageError):
     """A client contacted a server with an incomparible protocol

--- a/src/ZEO/tests/testZEO.py
+++ b/src/ZEO/tests/testZEO.py
@@ -1413,6 +1413,14 @@ call to the server. we'd get some sort of error here.
 
     """
 
+def ClientDisconnected_errors_are_TransientErrors():
+    """
+    >>> from ZEO.Exceptions import ClientDisconnected
+    >>> from transaction.interfaces import TransientError
+    >>> issubclass(ClientDisconnected, TransientError)
+    True
+    """
+
 if sys.platform.startswith('win'):
     del runzeo_logrotate_on_sigusr2
     del unix_domain_sockets


### PR DESCRIPTION
When applications retry jobs that raise transient errors, jobs (e.g. web
requests) with disconnect errors will be retried. Together with
blocking synchronous ZEO server calls for a limited time while
disconnected, this change should allow brief disconnections due to
server restart to avoid generating client-visible errors (e.g. 500
web responses).

Fixes #56 