### PR TITLE
Optionally use uvloop for clients

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,14 @@ matrix:
           python: 2.7
           env: ZEO4_SERVER=1
         - os: linux
-          python: 3.4
+          python: 3.5
           env: ZEO4_SERVER=1
         - os: linux
           python: 3.5
-          env: ZEO4_SERVER=1
+          env: BUILOUT_OPTIONS=extra=,uvloop
 install:
     - pip install zc.buildout
-    - buildout
+    - buildout $BUILOUT_OPTIONS
 cache:
   directories:
     - eggs

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -4,6 +4,7 @@ parts =
     test
     scripts
 versions = versions
+extra =
 
 [versions]
 
@@ -11,7 +12,7 @@ versions = versions
 [test]
 recipe = zc.recipe.testrunner
 eggs =
-    ZEO [test]
+    ZEO [test${buildout:extra}]
 initialization =
   import os, tempfile
   try: os.mkdir('tmp')
@@ -21,6 +22,5 @@ defaults = ['--all']
 
 [scripts]
 recipe = zc.recipe.egg
-eggs =
-    ZEO [test]
+eggs = ${test:eggs}
 interpreter = py

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ setup(name="ZEO",
       classifiers = classifiers,
       test_suite="__main__.alltests", # to support "setup.py test"
       tests_require = tests_require,
-      extras_require = dict(test=tests_require),
+      extras_require = dict(test=tests_require, uvloop=['uvloop']),
       install_requires = install_requires,
       zip_safe = False,
       entry_points = """

--- a/src/ZEO/asyncio/client.py
+++ b/src/ZEO/asyncio/client.py
@@ -2,8 +2,13 @@ from .._compat import PY3
 
 if PY3:
     import asyncio
+    try:
+        from uvloop import new_event_loop
+    except ImportError:
+        from asyncio import new_event_loop
 else:
     import trollius as asyncio
+    from trollius import new_event_loop
 
 from ZEO.Exceptions import ClientDisconnected
 import concurrent.futures
@@ -779,7 +784,7 @@ class ClientThread(ClientRunner):
     def run(self):
         loop = None
         try:
-            loop = asyncio.new_event_loop()
+            loop = new_event_loop()
             self.setup_delegation(loop)
             self.started.set()
             loop.run_forever()

--- a/src/ZEO/asyncio/client.py
+++ b/src/ZEO/asyncio/client.py
@@ -4,7 +4,6 @@ if PY3:
     import asyncio
     try:
         from uvloop import new_event_loop
-        print('USING_UVLOOP')
     except ImportError:
         from asyncio import new_event_loop
 else:

--- a/src/ZEO/asyncio/client.py
+++ b/src/ZEO/asyncio/client.py
@@ -4,6 +4,7 @@ if PY3:
     import asyncio
     try:
         from uvloop import new_event_loop
+        print('USING_UVLOOP')
     except ImportError:
         from asyncio import new_event_loop
 else:

--- a/src/ZEO/tests/testssl.py
+++ b/src/ZEO/tests/testssl.py
@@ -120,6 +120,7 @@ class SSLConfigTest(ZEOConfigTestBase):
 @mock.patch(('asyncio' if PY3 else 'trollius') + '.async')
 @mock.patch(('asyncio' if PY3 else 'trollius') + '.set_event_loop')
 @mock.patch(('asyncio' if PY3 else 'trollius') + '.new_event_loop')
+@mock.patch('ZEO.asyncio.client.new_event_loop')
 class SSLConfigTestMockiavellian(ZEOConfigTestBase):
 
     @mock.patch('ssl.create_default_context')


### PR DESCRIPTION
uvloop is a bit faster than the standard asyncion event loop.

Unfortunately, there's an issue with the ZEO tests and using uvloop in
the ZEO server:

  MagicStack/uvloop#39

Fortunately, most of the performance benefits of using uvloop seems to
be in the client.

For now, we'll just use ivloop on the client side, as the incremental
effort of using it in the server aren't worth futher wrestling with
the tests. (I spent quite a bit of time just narrowing down the cause
of the test issue.)

With this PR, if uvloop can be imported, it will be used for the
client. (uvloop requires Python 3.5 or later and doesn't support Windows.)