### PR TITLE
When creating an ad hoc server, a log file isn't created by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changelog
   the beginning of transactions to wait for any outstanding
   invalidations at the start of the transaction to be delivered.
 
+- When creating an ad hoc server, a log file isn't created by
+  default. You must pass a ``log`` option specifying a log file name.
+
 - The ZEO server register method now returns the storage last
   transaction, allowing the client to avoid an extra round trip during
   cache verification.

--- a/src/ZEO/tests/ConnectionTests.py
+++ b/src/ZEO/tests/ConnectionTests.py
@@ -156,7 +156,7 @@ class CommonSetupTearDown(StorageTestBase):
         return {}
 
     def getServerConfig(self, addr, ro_svr):
-        zconf = forker.ZEOConfig(addr)
+        zconf = forker.ZEOConfig(addr, log='server.log')
         if ro_svr:
             zconf.read_only = 1
         if self.invq:

--- a/src/ZEO/tests/forker.py
+++ b/src/ZEO/tests/forker.py
@@ -44,12 +44,19 @@ skip_if_testing_client_against_zeo4 = (
 class ZEOConfig:
     """Class to generate ZEO configuration file. """
 
-    def __init__(self, addr, **options):
-        if isinstance(addr, str):
-            self.logpath = addr+'.log'
-        else:
-            self.logpath = 'server.log'
+    def __init__(self, addr, log=None, **options):
+        if log:
+            if isinstance(log, str):
+                self.logpath = log
+            elif isinstance(addr, str):
+                self.logpath = addr+'.log'
+            else:
+                self.logpath = 'server.log'
+
+        if not isinstance(addr, str):
             addr = '%s:%s' % addr
+
+        self.log = log
         self.address = addr
         self.read_only = None
         self.loglevel = 'INFO'
@@ -72,14 +79,15 @@ class ZEOConfig:
 
         print("</zeo>", file=f)
 
-        print("""
-        <eventlog>
-          level %s
-          <logfile>
-             path %s
-          </logfile>
-        </eventlog>
-        """ % (self.loglevel, self.logpath), file=f)
+        if self.log:
+            print("""
+            <eventlog>
+              level %s
+              <logfile>
+                 path %s
+              </logfile>
+            </eventlog>
+            """ % (self.loglevel, self.logpath), file=f)
 
     def __str__(self):
         f = StringIO()
@@ -191,7 +199,7 @@ def stop_runner(thread, config, qin, qout, stop_timeout=19, pid=None):
 def start_zeo_server(storage_conf=None, zeo_conf=None, port=None, keep=False,
                      path='Data.fs', protocol=None, blob_dir=None,
                      suicide=True, debug=False,
-                     threaded=False, start_timeout=33, name=None,
+                     threaded=False, start_timeout=33, name=None, log=None,
                      ):
     """Start a ZEO server in a separate process.
 
@@ -218,7 +226,7 @@ def start_zeo_server(storage_conf=None, zeo_conf=None, port=None, keep=False,
         else:
             addr = port
 
-        z = ZEOConfig(addr)
+        z = ZEOConfig(addr, log=log)
         if zeo_conf:
             z.__dict__.update(zeo_conf)
         zeo_conf = str(z)

--- a/src/ZEO/tests/testZEO.py
+++ b/src/ZEO/tests/testZEO.py
@@ -148,12 +148,13 @@ class GenericTestBase(
 
     shared_blob_dir = False
     blob_cache_dir = None
+    server_debug = False
 
     def setUp(self):
         StorageTestBase.StorageTestBase.setUp(self)
         logger.info("setUp() %s", self.id())
-        zport, stop = forker.start_zeo_server(self.getConfig(),
-                                              self.getZEOConfig())
+        zport, stop = forker.start_zeo_server(
+            self.getConfig(), self.getZEOConfig(), debug=self.server_debug)
         self._servers = [stop]
         if not self.blob_cache_dir:
             # This is the blob cache for ClientStorage
@@ -1010,7 +1011,7 @@ def history_over_zeo():
 
 def dont_log_poskeyerrors_on_server():
     """
-    >>> addr, admin = start_server()
+    >>> addr, admin = start_server(log='server.log')
     >>> cs = ClientStorage(addr)
     >>> cs.load(ZODB.utils.p64(1))
     Traceback (most recent call last):
@@ -1190,7 +1191,7 @@ log entries with actual clients.  It's possible, sort of, but tedious.
 You can make this easier by passing a label to the ClientStorage
 constructor.
 
-    >>> addr, _ = start_server()
+    >>> addr, _ = start_server(log='server.log')
     >>> db = ZEO.DB(addr, client_label='test-label-1')
     >>> db.close()
     >>> @wait_until
@@ -1346,11 +1347,6 @@ def runzeo_logrotate_on_sigusr2():
     >>> oldlog = read('l')
     >>> os.rename('l', 'o')
     >>> os.kill(p.pid, signal.SIGUSR2)
-
-    >>> wait_until('new file', lambda : os.path.exists('l'))
-
-    XXX: if any of the previous commands failed, we'll hang here trying to
-    connect to ZEO, because doctest runs all the assertions...
 
     >>> s = ClientStorage(port)
     >>> s.close()


### PR DESCRIPTION
You must pass a log option specifying a log file name.