### PR TITLE
Exit with failure codes instead of success codes on unsupported Python versions.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+5.0.2 (unreleased)
+------------------
+
+- Provide better error messages when pip tries to install ZEO on an
+  unsupported Python version. See `issue 75 <https://github.com/zopefoundation/ZEO/issues/75>`_.
+
 5.0.1 (2016-09-06)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,11 @@ import sys
 
 if sys.version_info < (2, 7, 9):
     print("This version of ZEO requires Python 2.7.9 or higher")
-    sys.exit(0)
+    sys.exit(1)
 
 if (3, 0) < sys.version_info < (3, 4):
     print("This version of ZEO requires Python 3.4 or higher")
-    sys.exit(0)
+    sys.exit(1)
 
 install_requires = [
     'ZODB >= 5.0.0a5',


### PR DESCRIPTION
Fixes #75.