### PR TITLE
Msgpack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,10 @@ matrix:
           env: ZEO_MTACCEPTOR=1
         - os: linux
           python: 3.5
-          env: ZEO_MTACCEPTOR=1
+          env: ZEO_MSGPACK=1 ZEO_MTACCEPTOR=1
+        - os: linux
+          python: 2.7
+          env: ZEO_MSGPACK=1
         - os: linux
           python: 2.7
           env: ZEO4_SERVER=1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+- Added support for serializing ZEO messages using `msgpack
+  <http://msgpack.org/index.html>`_ rather than pickle.  This helps
+  pave the way to supporting `byteserver
+  <https://github.com/jimfulton/byteserver>`_, but it also allows ZEO
+  servers to support Python 2 or 3 clients (but not both at the same
+  time) and may provide a small performance improvement.
+
 5.0.2 (2016-11-02)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,6 @@ Changelog
 
 - Temporarily require non-quite-current versions of ZODB and
   transaction until we can sort out some recent breakage.
->>>>>>> origin/master
 
 5.0.2 (2016-11-02)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -290,7 +290,8 @@ client-conflict-resolution
         resolution. This option defaults to false.
 
 msgpack
-        Use msgpack to serialize and de-serialize ZEO protocol messages.
+        Use `msgpack <http://msgpack.org/index.html>`_ to serialize
+        and de-serialize ZEO protocol messages.
 
         An advantage of using msgpack for ZEO communication is that
         it's a tiny bit faster and a ZEO server can support Python 2

--- a/README.rst
+++ b/README.rst
@@ -293,8 +293,11 @@ msgpack
         Use msgpack to serialize and de-serialize ZEO protocol messages.
 
         An advantage of using msgpack for ZEO communication is that
-        it's a little bit faster and a ZEO server can support Python 2
+        it's a tiny bit faster and a ZEO server can support Python 2
         or Python 3 clients (but not both).
+
+        msgpack can also be enabled by setting the ``ZEO_MSGPACK``
+        environment to a non-empty string.
 
 Server SSL configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -289,6 +289,13 @@ client-conflict-resolution
         Flag indicating that clients should perform conflict
         resolution. This option defaults to false.
 
+msgpack
+        Use msgpack to serialize and de-serialize ZEO protocol messages.
+
+        An advantage of using msgpack for ZEO communication is that
+        it's a little bit faster and a ZEO server can support Python 2
+        or Python 3 clients (but not both).
+
 Server SSL configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ if (3, 0) < sys.version_info < (3, 4):
 install_requires = [
     'ZODB >= 5.0.0a5',
     'six',
-    'transaction >= 1.6.0',
+    'transaction >= 2.0.2',
     'persistent >= 4.1.0',
     'zc.lockfile',
     'ZConfig',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ install_requires = [
     'zope.interface',
     ]
 
-tests_require = ['zope.testing', 'manuel', 'random2', 'mock']
+tests_require = ['zope.testing', 'manuel', 'random2', 'mock', 'msgpack-python']
 
 if sys.version_info[:2] < (3, ):
     install_requires.extend(('futures', 'trollius'))
@@ -128,7 +128,11 @@ setup(name="ZEO",
       classifiers = classifiers,
       test_suite="__main__.alltests", # to support "setup.py test"
       tests_require = tests_require,
-      extras_require = dict(test=tests_require, uvloop=['uvloop >=0.5.1']),
+      extras_require = dict(
+          test=tests_require,
+          uvloop=['uvloop >=0.5.1'],
+          msgpack=['msgpack-python'],
+          ),
       install_requires = install_requires,
       zip_safe = False,
       entry_points = """

--- a/src/ZEO/ClientStorage.py
+++ b/src/ZEO/ClientStorage.py
@@ -383,7 +383,7 @@ class ClientStorage(ZODB.ConflictResolution.ConflictResolvingStorage):
                 'interfaces', ()):
                 zope.interface.alsoProvides(self, iface)
 
-        if self.protocol_version >= b'Z5':
+        if self.protocol_version[1:] >= b'5':
             self.ping = lambda : self._call('ping')
         else:
             self.ping = lambda : self._call('lastTransaction')

--- a/src/ZEO/StorageServer.py
+++ b/src/ZEO/StorageServer.py
@@ -228,7 +228,7 @@ class ZEOStorage:
         storage = self.storage
 
         supportsUndo = (getattr(storage, 'supportsUndo', lambda : False)()
-                        and self.connection.protocol_version >= b'Z310')
+                        and self.connection.protocol_version[1:] >= b'310')
 
         # Communicate the backend storage interfaces to the client
         storage_provides = zope.interface.providedBy(storage)

--- a/src/ZEO/StorageServer.py
+++ b/src/ZEO/StorageServer.py
@@ -663,6 +663,7 @@ class StorageServer:
                  ssl=None,
                  client_conflict_resolution=False,
                  Acceptor=Acceptor,
+                 msgpack=False,
                  ):
         """StorageServer constructor.
 
@@ -757,7 +758,7 @@ class StorageServer:
         self.client_conflict_resolution = client_conflict_resolution
 
         if addr is not None:
-            self.acceptor = Acceptor(self, addr, ssl)
+            self.acceptor = Acceptor(self, addr, ssl, msgpack)
             if isinstance(addr, tuple) and addr[0]:
                 self.addr = self.acceptor.addr
             else:

--- a/src/ZEO/asyncio/base.py
+++ b/src/ZEO/asyncio/base.py
@@ -127,7 +127,6 @@ class Protocol(asyncio.Protocol):
                     self.getting_size = True
                     self.message_received(collected)
             except Exception:
-                #import traceback; traceback.print_exc()
                 logger.exception("data_received %s %s %s",
                                  self.want, self.got, self.getting_size)
 

--- a/src/ZEO/asyncio/base.py
+++ b/src/ZEO/asyncio/base.py
@@ -10,8 +10,6 @@ import socket
 from struct import unpack
 import sys
 
-from .marshal import encoder
-
 logger = logging.getLogger(__name__)
 
 INET_FAMILIES = socket.AF_INET, socket.AF_INET6
@@ -129,13 +127,13 @@ class Protocol(asyncio.Protocol):
                     self.getting_size = True
                     self.message_received(collected)
             except Exception:
+                #import traceback; traceback.print_exc()
                 logger.exception("data_received %s %s %s",
                                  self.want, self.got, self.getting_size)
 
     def first_message_received(self, protocol_version):
         # Handler for first/handshake message, set up in __init__
         del self.message_received # use default handler from here on
-        self.encode = encoder()
         self.finish_connect(protocol_version)
 
     def call_async(self, method, args):

--- a/src/ZEO/asyncio/client.py
+++ b/src/ZEO/asyncio/client.py
@@ -13,7 +13,7 @@ import ZEO.interfaces
 
 from . import base
 from .compat import asyncio, new_event_loop
-from .marshal import decode
+from .marshal import encoder, decoder
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ class Protocol(base.Protocol):
     # One place where special care was required was in cache setup on
     # connect. See finish connect below.
 
-    protocols = b'Z309', b'Z310', b'Z3101', b'Z4', b'Z5'
+    protocols = b'309', b'310', b'3101', b'4', b'5'
 
     def __init__(self, loop,
                  addr, client, storage_key, read_only, connect_poll=1,
@@ -150,6 +150,8 @@ class Protocol(base.Protocol):
             # We have to be careful processing the futures, because
             # exception callbacks might modufy them.
             for f in self.pop_futures():
+                if isinstance(f, tuple):
+                    continue
                 f.set_exception(ClientDisconnected(exc or 'connection lost'))
             self.closed = True
             self.client.disconnected(self)
@@ -165,12 +167,16 @@ class Protocol(base.Protocol):
         # lastTid before processing (and possibly missing) subsequent
         # invalidations.
 
-        self.protocol_version = min(protocol_version, self.protocols[-1])
-
-        if self.protocol_version not in self.protocols:
+        version = min(protocol_version[1:], self.protocols[-1])
+        if version not in self.protocols:
             self.client.register_failed(
                 self, ZEO.Exceptions.ProtocolError(protocol_version))
             return
+
+        self.protocol_version = protocol_version[:1] + version
+        self.encode = encoder(protocol_version)
+        self.decode = decoder(protocol_version)
+        self.heartbeat_bytes = self.encode(-1, 0, '.reply', None)
 
         self._write(self.protocol_version)
 
@@ -199,9 +205,12 @@ class Protocol(base.Protocol):
 
     exception_type_type = type(Exception)
     def message_received(self, data):
-        msgid, async, name, args = decode(data)
+        msgid, async, name, args = self.decode(data)
         if name == '.reply':
             future = self.futures.pop(msgid)
+            if isinstance(future, tuple):
+                future = self.futures.pop(future)
+
             if (async): # ZEO 5 exception
                 class_, args = args
                 factory = exc_factories.get(class_)
@@ -245,13 +254,15 @@ class Protocol(base.Protocol):
 
     def load_before(self, oid, tid):
         # Special-case loadBefore, so we collapse outstanding requests
-        message_id = (oid, tid)
-        future = self.futures.get(message_id)
+        oid_tid = (oid, tid)
+        future = self.futures.get(oid_tid)
         if future is None:
             future = asyncio.Future(loop=self.loop)
-            self.futures[message_id] = future
+            self.futures[oid_tid] = future
+            self.message_id += 1
+            self.futures[self.message_id] = oid_tid
             self._write(
-                self.encode(message_id, False, 'loadBefore', (oid, tid)))
+                self.encode(self.message_id, False, 'loadBefore', (oid, tid)))
         return future
 
     # Methods called by the server.
@@ -267,7 +278,7 @@ class Protocol(base.Protocol):
 
     def heartbeat(self, write=True):
         if write:
-            self._write(b'(J\xff\xff\xff\xffK\x00U\x06.replyNt.')
+            self._write(self.heartbeat_bytes)
         self.heartbeat_handle = self.loop.call_later(
             self.heartbeat_interval, self.heartbeat)
 

--- a/src/ZEO/asyncio/marshal.py
+++ b/src/ZEO/asyncio/marshal.py
@@ -26,14 +26,17 @@ from ..shortrepr import short_repr
 
 logger = logging.getLogger(__name__)
 
-def encoder(protocol):
+def encoder(protocol, server=False):
     """Return a non-thread-safe encoder
     """
 
     if protocol[:1] == b'M':
         from msgpack import packb
+        default = server_default if server else None
         def encode(*args):
-            return packb(args, use_bin_type=True)
+            return packb(
+                args, use_bin_type=True, default=default)
+
         return encode
     else:
         assert protocol[:1] == b'Z'
@@ -69,7 +72,7 @@ def decoder(protocol):
         from msgpack import unpackb
         def msgpack_decode(data):
             """Decodes msg and returns its parts"""
-            return unpackb(data, encoding='utf-8')
+            return unpackb(data, encoding='utf-8', use_list=False)
         return msgpack_decode
     else:
         assert protocol[:1] == b'Z'
@@ -112,6 +115,17 @@ def pickle_server_decode(msg):
     except:
         logger.error("can't decode message: %s" % short_repr(msg))
         raise
+
+def server_default(obj):
+    if isinstance(obj, Exception):
+        return reduce_exception(obj)
+    else:
+        return obj
+
+def reduce_exception(exc):
+    class_ = exc.__class__
+    class_ = "%s.%s" % (class_.__module__, class_.__name__)
+    return class_, exc.__dict__ or exc.args
 
 _globals = globals()
 _silly = ('__doc__',)

--- a/src/ZEO/asyncio/mtacceptor.py
+++ b/src/ZEO/asyncio/mtacceptor.py
@@ -76,13 +76,14 @@ class Acceptor(asyncore.dispatcher):
     And creates a separate thread for each.
     """
 
-    def __init__(self, storage_server, addr, ssl):
+    def __init__(self, storage_server, addr, ssl, msgpack):
         self.storage_server = storage_server
         self.addr = addr
         self.__socket_map = {}
         asyncore.dispatcher.__init__(self, map=self.__socket_map)
 
         self.ssl_context = ssl
+        self.msgpack = msgpack
         self._open_socket()
 
     def _open_socket(self):
@@ -165,7 +166,7 @@ class Acceptor(asyncore.dispatcher):
             def run():
                 loop = new_event_loop()
                 zs = self.storage_server.create_client_handler()
-                protocol = ServerProtocol(loop, self.addr, zs)
+                protocol = ServerProtocol(loop, self.addr, zs, self.msgpack)
                 protocol.stop = loop.stop
 
                 if self.ssl_context is None:

--- a/src/ZEO/asyncio/server.py
+++ b/src/ZEO/asyncio/server.py
@@ -11,13 +11,13 @@ from ..shortrepr import short_repr
 
 from . import base
 from .compat import asyncio, new_event_loop
-from .marshal import server_decode
+from .marshal import server_decoder, encoder
 
 class ServerProtocol(base.Protocol):
     """asyncio low-level ZEO server interface
     """
 
-    protocols = (b'Z5', )
+    protocols = (b'5', )
 
     name = 'server protocol'
     methods = set(('register', ))
@@ -26,11 +26,15 @@ class ServerProtocol(base.Protocol):
         ZODB.POSException.POSKeyError,
         )
 
-    def __init__(self, loop, addr, zeo_storage):
+    def __init__(self, loop, addr, zeo_storage, msgpack):
         """Create a server's client interface
         """
         super(ServerProtocol, self).__init__(loop, addr)
         self.zeo_storage = zeo_storage
+
+        self.announce_protocol = (
+          (b'M' if msgpack else b'Z') + best_protocol_version
+        )
 
     closed = False
     def close(self):
@@ -44,7 +48,7 @@ class ServerProtocol(base.Protocol):
     def connection_made(self, transport):
         self.connected = True
         super(ServerProtocol, self).connection_made(transport)
-        self._write(best_protocol_version)
+        self._write(self.announce_protocol)
 
     def connection_lost(self, exc):
         self.connected = False
@@ -61,10 +65,13 @@ class ServerProtocol(base.Protocol):
             self._write(json.dumps(self.zeo_storage.ruok()).encode("ascii"))
             self.close()
         else:
-            if protocol_version in self.protocols:
+            version = protocol_version[1:]
+            if version in self.protocols:
                 logger.info("received handshake %r" %
                             str(protocol_version.decode('ascii')))
                 self.protocol_version = protocol_version
+                self.encode = encoder(protocol_version)
+                self.decode = server_decoder(protocol_version)
                 self.zeo_storage.notify_connected(self)
             else:
                 logger.error("bad handshake %s" % short_repr(protocol_version))
@@ -79,7 +86,7 @@ class ServerProtocol(base.Protocol):
 
     def message_received(self, message):
         try:
-            message_id, async, name, args = server_decode(message)
+            message_id, async, name, args = self.decode(message)
         except Exception:
             logger.exception("Can't deserialize message")
             self.close()
@@ -144,8 +151,8 @@ best_protocol_version = os.environ.get(
     ServerProtocol.protocols[-1].decode('utf-8')).encode('utf-8')
 assert best_protocol_version in ServerProtocol.protocols
 
-def new_connection(loop, addr, socket, zeo_storage):
-    protocol = ServerProtocol(loop, addr, zeo_storage)
+def new_connection(loop, addr, socket, zeo_storage, msgpack):
+    protocol = ServerProtocol(loop, addr, zeo_storage, msgpack)
     cr = loop.create_connection((lambda : protocol), sock=socket)
     asyncio.async(cr, loop=loop)
 
@@ -213,10 +220,11 @@ class MTDelay(Delay):
 
 class Acceptor(object):
 
-    def __init__(self, storage_server, addr, ssl):
+    def __init__(self, storage_server, addr, ssl, msgpack):
         self.storage_server = storage_server
         self.addr = addr
         self.ssl_context = ssl
+        self.msgpack = msgpack
         self.event_loop = loop = new_event_loop()
 
         if isinstance(addr, tuple):
@@ -243,7 +251,8 @@ class Acceptor(object):
         try:
             logger.debug("Accepted connection")
             zs = self.storage_server.create_client_handler()
-            protocol = ServerProtocol(self.event_loop, self.addr, zs)
+            protocol = ServerProtocol(
+                self.event_loop, self.addr, zs, self.msgpack)
         except Exception:
             logger.exception("Failure in protocol factory")
 

--- a/src/ZEO/asyncio/tests.py
+++ b/src/ZEO/asyncio/tests.py
@@ -199,9 +199,9 @@ class ClientTests(Base, setupstack.TestCase, ClientRunner):
         loaded = self.load_before(b'1'*8, maxtid)
 
         # The data wasn't in the cache, so we made a server call:
-        self.assertEqual(self.pop(), (5, False, 'loadBefore', (b'1'*8, maxtid)))
+        self.assertEqual(self.pop(), ((b'1'*8, maxtid), False, 'loadBefore', (b'1'*8, maxtid)))
         # Note load_before uses the oid as the message id.
-        self.respond(5, (b'data', b'a'*8, None))
+        self.respond((b'1'*8, maxtid), (b'data', b'a'*8, None))
         self.assertEqual(loaded.result(), (b'data', b'a'*8, None))
 
         # If we make another request, it will be satisfied from the cache:
@@ -219,8 +219,8 @@ class ClientTests(Base, setupstack.TestCase, ClientRunner):
         # the requests will be collapsed:
         loaded2 = self.load_before(b'1'*8, maxtid)
 
-        self.assertEqual(self.pop(), (6, False, 'loadBefore', (b'1'*8, maxtid)))
-        self.respond(6, (b'data2', b'b'*8, None))
+        self.assertEqual(self.pop(), ((b'1'*8, maxtid), False, 'loadBefore', (b'1'*8, maxtid)))
+        self.respond((b'1'*8, maxtid), (b'data2', b'b'*8, None))
         self.assertEqual(loaded.result(), (b'data2', b'b'*8, None))
         self.assertEqual(loaded2.result(), (b'data2', b'b'*8, None))
 
@@ -233,8 +233,8 @@ class ClientTests(Base, setupstack.TestCase, ClientRunner):
         self.assertFalse(transport.data)
         loaded = self.load_before(b'1'*8, b'_'*8)
 
-        self.assertEqual(self.pop(), (7, False, 'loadBefore', (b'1'*8, b'_'*8)))
-        self.respond(7, (b'data0', b'^'*8, b'_'*8))
+        self.assertEqual(self.pop(), ((b'1'*8, b'_'*8), False, 'loadBefore', (b'1'*8, b'_'*8)))
+        self.respond((b'1'*8, b'_'*8), (b'data0', b'^'*8, b'_'*8))
         self.assertEqual(loaded.result(), (b'data0', b'^'*8, b'_'*8))
 
         # When committing transactions, we need to update the cache
@@ -257,8 +257,8 @@ class ClientTests(Base, setupstack.TestCase, ClientRunner):
                          cache.load(b'4'*8))
         self.assertEqual(cache.load(b'1'*8), (b'data2', b'b'*8))
         self.assertEqual(self.pop(),
-                         (8, False, 'tpc_finish', (b'd'*8,)))
-        self.respond(8, b'e'*8)
+                         (5, False, 'tpc_finish', (b'd'*8,)))
+        self.respond(5, b'e'*8)
         self.assertEqual(committed.result(), b'e'*8)
         self.assertEqual(cache.load(b'1'*8), None)
         self.assertEqual(cache.load(b'2'*8), ('committed 2', b'e'*8))
@@ -272,8 +272,9 @@ class ClientTests(Base, setupstack.TestCase, ClientRunner):
         self.assertFalse(loaded.done() or f1.done())
         self.assertEqual(
             self.pop(),
-            [(9, False, 'loadBefore', (b'1'*8, maxtid)),
-             (10, False, 'foo', (1, 2))],
+            [((b'11111111', b'\x7f\xff\xff\xff\xff\xff\xff\xff'),
+              False, 'loadBefore', (b'1'*8, maxtid)),
+             (6, False, 'foo', (1, 2))],
             )
         exc = TypeError(43)
 

--- a/src/ZEO/runzeo.py
+++ b/src/ZEO/runzeo.py
@@ -343,7 +343,8 @@ def create_server(storages, options):
         storages,
         read_only = options.read_only,
         client_conflict_resolution=options.client_conflict_resolution,
-        msgpack=options.msgpack or os.environ.get('ZEO_MSGPACK'),
+        msgpack=(options.msgpack if isinstance(options.msgpack, bool)
+                 else os.environ.get('ZEO_MSGPACK')),
         invalidation_queue_size = options.invalidation_queue_size,
         invalidation_age = options.invalidation_age,
         transaction_timeout = options.transaction_timeout,

--- a/src/ZEO/runzeo.py
+++ b/src/ZEO/runzeo.py
@@ -343,7 +343,7 @@ def create_server(storages, options):
         storages,
         read_only = options.read_only,
         client_conflict_resolution=options.client_conflict_resolution,
-        msgpack=options.msgpack,
+        msgpack=options.msgpack or os.environ.get('ZEO_MSGPACK'),
         invalidation_queue_size = options.invalidation_queue_size,
         invalidation_age = options.invalidation_age,
         transaction_timeout = options.transaction_timeout,

--- a/src/ZEO/runzeo.py
+++ b/src/ZEO/runzeo.py
@@ -100,6 +100,7 @@ class ZEOOptionsMixin:
         self.add("client_conflict_resolution",
                  "zeo.client_conflict_resolution",
                  default=0)
+        self.add("msgpack", "zeo.msgpack", default=0)
         self.add("invalidation_queue_size", "zeo.invalidation_queue_size",
                  default=100)
         self.add("invalidation_age", "zeo.invalidation_age")
@@ -342,6 +343,7 @@ def create_server(storages, options):
         storages,
         read_only = options.read_only,
         client_conflict_resolution=options.client_conflict_resolution,
+        msgpack=options.msgpack,
         invalidation_queue_size = options.invalidation_queue_size,
         invalidation_age = options.invalidation_age,
         transaction_timeout = options.transaction_timeout,

--- a/src/ZEO/server.xml
+++ b/src/ZEO/server.xml
@@ -120,8 +120,11 @@
         Use msgpack to serialize and de-serialize ZEO protocol messages.
 
         An advantage of using msgpack for ZEO communication is that
-        it's a little bit faster and a ZEO server can support Python 2
+        it's a tiny bit faster and a ZEO server can support Python 2
         or Python 3 clients (but not both).
+
+        msgpack can also be enabled by setting the ``ZEO_MSGPACK``
+        environment to a non-empty string.
       </description>
     </key>
 

--- a/src/ZEO/server.xml
+++ b/src/ZEO/server.xml
@@ -115,6 +115,16 @@
       </description>
     </key>
 
+    <key name="msgpack" datatype="boolean" required="no" default="false">
+      <description>
+        Use msgpack to serialize and de-serialize ZEO protocol messages.
+
+        An advantage of using msgpack for ZEO communication is that
+        it's a little bit faster and a ZEO server can support Python 2
+        or Python 3 clients (but not both).
+      </description>
+    </key>
+
   </sectiontype>
 
 </component>

--- a/src/ZEO/server.xml
+++ b/src/ZEO/server.xml
@@ -115,7 +115,7 @@
       </description>
     </key>
 
-    <key name="msgpack" datatype="boolean" required="no" default="false">
+    <key name="msgpack" datatype="boolean" required="no">
       <description>
         Use msgpack to serialize and de-serialize ZEO protocol messages.
 

--- a/src/ZEO/tests/forker.py
+++ b/src/ZEO/tests/forker.py
@@ -70,7 +70,7 @@ class ZEOConfig:
 
         for name in (
             'invalidation_queue_size', 'invalidation_age',
-            'transaction_timeout', 'pid_filename',
+            'transaction_timeout', 'pid_filename', 'msgpack',
             'ssl_certificate', 'ssl_key', 'client_conflict_resolution',
             ):
             v = getattr(self, name, None)
@@ -200,6 +200,7 @@ def start_zeo_server(storage_conf=None, zeo_conf=None, port=None, keep=False,
                      path='Data.fs', protocol=None, blob_dir=None,
                      suicide=True, debug=False,
                      threaded=False, start_timeout=33, name=None, log=None,
+                     show_config=False
                      ):
     """Start a ZEO server in a separate process.
 
@@ -231,11 +232,14 @@ def start_zeo_server(storage_conf=None, zeo_conf=None, port=None, keep=False,
             z.__dict__.update(zeo_conf)
         zeo_conf = str(z)
 
+    zeo_conf = str(zeo_conf) + '\n\n' + storage_conf
+    if show_config:
+        print(zeo_conf)
+
     # Store the config info in a temp file.
     tmpfile = tempfile.mktemp(".conf", dir=os.getcwd())
     fp = open(tmpfile, 'w')
-    fp.write(str(zeo_conf) + '\n\n')
-    fp.write(storage_conf)
+    fp.write(zeo_conf)
     fp.close()
 
     if threaded:

--- a/src/ZEO/tests/protocols.test
+++ b/src/ZEO/tests/protocols.test
@@ -24,8 +24,8 @@ A current client should be able to connect to a old server:
     >>> import ZEO, ZODB.blob, transaction
     >>> db = ZEO.DB(addr, client='client', blob_dir='blobs')
     >>> wait_connected(db.storage)
-    >>> str(db.storage.protocol_version.decode('ascii'))
-    'Z4'
+    >>> str(db.storage.protocol_version.decode('ascii'))[1:]
+    '4'
 
     >>> conn = db.open()
     >>> conn.root().x = 0

--- a/src/ZEO/tests/protocols.test
+++ b/src/ZEO/tests/protocols.test
@@ -17,7 +17,7 @@ Let's start a Z4 server
     ... '''
 
     >>> addr, stop = start_server(
-    ...    storage_conf, dict(invalidation_queue_size=5), protocol=b'Z4')
+    ...    storage_conf, dict(invalidation_queue_size=5), protocol=b'4')
 
 A current client should be able to connect to a old server:
 

--- a/src/ZEO/tests/servertesting.py
+++ b/src/ZEO/tests/servertesting.py
@@ -44,7 +44,7 @@ class StorageServer(ZEO.StorageServer.StorageServer):
 def client(server, name='client'):
     zs = ZEO.StorageServer.ZEOStorage(server)
     protocol = ZEO.asyncio.tests.server_protocol(
-        zs, protocol_version=b'Z5', addr='test-addr-%s' % name)
+        False, zs, protocol_version=b'Z5', addr='test-addr-%s' % name)
     zs.notify_connected(protocol)
     zs.register('1', 0)
     return zs

--- a/src/ZEO/tests/testZEO.py
+++ b/src/ZEO/tests/testZEO.py
@@ -1465,34 +1465,35 @@ def ClientDisconnected_errors_are_TransientErrors():
     True
     """
 
-if os.environ.get('ZEO_MSGPACK'):
-    def test_runzeo_msgpack_support():
-        """
-        >>> import ZEO
+if not os.environ.get('ZEO4_SERVER'):
+    if os.environ.get('ZEO_MSGPACK'):
+        def test_runzeo_msgpack_support():
+            """
+            >>> import ZEO
 
-        >>> a, s = ZEO.server(threaded=False)
-        >>> conn = ZEO.connection(a)
-        >>> str(conn.db().storage.protocol_version.decode('ascii'))
-        'M5'
-        >>> conn.close(); s()
-        """
-else:
-    def test_runzeo_msgpack_support():
-        """
-        >>> import ZEO
+            >>> a, s = ZEO.server(threaded=False)
+            >>> conn = ZEO.connection(a)
+            >>> str(conn.db().storage.protocol_version.decode('ascii'))
+            'M5'
+            >>> conn.close(); s()
+            """
+    else:
+        def test_runzeo_msgpack_support():
+            """
+            >>> import ZEO
 
-        >>> a, s = ZEO.server(threaded=False)
-        >>> conn = ZEO.connection(a)
-        >>> str(conn.db().storage.protocol_version.decode('ascii'))
-        'Z5'
-        >>> conn.close(); s()
+            >>> a, s = ZEO.server(threaded=False)
+            >>> conn = ZEO.connection(a)
+            >>> str(conn.db().storage.protocol_version.decode('ascii'))
+            'Z5'
+            >>> conn.close(); s()
 
-        >>> a, s = ZEO.server(zeo_conf=dict(msgpack=True), threaded=False)
-        >>> conn = ZEO.connection(a)
-        >>> str(conn.db().storage.protocol_version.decode('ascii'))
-        'M5'
-        >>> conn.close(); s()
-        """
+            >>> a, s = ZEO.server(zeo_conf=dict(msgpack=True), threaded=False)
+            >>> conn = ZEO.connection(a)
+            >>> str(conn.db().storage.protocol_version.decode('ascii'))
+            'M5'
+            >>> conn.close(); s()
+            """
 
 if sys.platform.startswith('win'):
     del runzeo_logrotate_on_sigusr2

--- a/src/ZEO/tests/testZEO.py
+++ b/src/ZEO/tests/testZEO.py
@@ -1462,6 +1462,35 @@ def ClientDisconnected_errors_are_TransientErrors():
     True
     """
 
+if os.environ.get('ZEO_MSGPACK'):
+    def test_runzeo_msgpack_support():
+        """
+        >>> import ZEO
+
+        >>> a, s = ZEO.server()
+        >>> conn = ZEO.connection(a)
+        >>> str(conn.db().storage.protocol_version.decode('ascii'))
+        'M5'
+        >>> conn.close(); s()
+        """
+else:
+    def test_runzeo_msgpack_support():
+        """
+        >>> import ZEO
+
+        >>> a, s = ZEO.server()
+        >>> conn = ZEO.connection(a)
+        >>> str(conn.db().storage.protocol_version.decode('ascii'))
+        'Z5'
+        >>> conn.close(); s()
+
+        >>> a, s = ZEO.server(zeo_conf=dict(msgpack=True))
+        >>> conn = ZEO.connection(a)
+        >>> str(conn.db().storage.protocol_version.decode('ascii'))
+        'M5'
+        >>> conn.close(); s()
+        """
+
 if sys.platform.startswith('win'):
     del runzeo_logrotate_on_sigusr2
     del unix_domain_sockets

--- a/src/ZEO/tests/testZEO.py
+++ b/src/ZEO/tests/testZEO.py
@@ -1470,7 +1470,7 @@ if os.environ.get('ZEO_MSGPACK'):
         """
         >>> import ZEO
 
-        >>> a, s = ZEO.server()
+        >>> a, s = ZEO.server(threaded=False)
         >>> conn = ZEO.connection(a)
         >>> str(conn.db().storage.protocol_version.decode('ascii'))
         'M5'
@@ -1481,13 +1481,13 @@ else:
         """
         >>> import ZEO
 
-        >>> a, s = ZEO.server()
+        >>> a, s = ZEO.server(threaded=False)
         >>> conn = ZEO.connection(a)
         >>> str(conn.db().storage.protocol_version.decode('ascii'))
         'Z5'
         >>> conn.close(); s()
 
-        >>> a, s = ZEO.server(zeo_conf=dict(msgpack=True))
+        >>> a, s = ZEO.server(zeo_conf=dict(msgpack=True), threaded=False)
         >>> conn = ZEO.connection(a)
         >>> str(conn.db().storage.protocol_version.decode('ascii'))
         'M5'

--- a/src/ZEO/tests/utils.py
+++ b/src/ZEO/tests/utils.py
@@ -39,7 +39,7 @@ class StorageServer:
     """
 
     def __init__(self, test, storage,
-                 protocol_version=best_protocol_version,
+                 protocol_version=b'Z' + best_protocol_version,
                  **kw):
         self.test = test
         self.storage_server = ZEO.StorageServer.StorageServer(


### PR DESCRIPTION
This PR adds optional msgpack support.

If you build the client and server using the msgpack extra and configure the server to use msgpack (via the config file or an environment variable), then msgpack will be used for the wire protocol. 

Why:

- byteserver in the future

- Python version independence of the ZEO server.  A Server running Python 3 can work with a
  client running Python 2.