### PR TITLE
WIP: tests: run generic ZODBTests from ZODB

### DIFF
--- a/src/ZEO/tests/testZEO.py
+++ b/src/ZEO/tests/testZEO.py
@@ -22,7 +22,7 @@ from ZEO.tests import IterationTests
 from ZEO._compat import PY3
 
 from ZODB.Connection import TransactionMetaData
-from ZODB.tests import StorageTestBase, BasicStorage,  \
+from ZODB.tests import testZODB, StorageTestBase, BasicStorage,  \
      TransactionalUndoStorage,  \
      PackableStorage, Synchronization, ConflictResolution, RevisionStorage, \
      MTStorage, ReadOnlyStorage, IteratorStorage, RecoveryStorage
@@ -310,7 +310,7 @@ class FileStorageRecoveryTests(StorageTestBase.StorageTestBase,
         return self._new_storage()
 
 
-class FileStorageTests(FullGenericTests):
+class FileStorageTests(FullGenericTests, testZODB.ZODBTests):
     """Test ZEO backed by a FileStorage."""
 
     def getConfig(self):
@@ -342,6 +342,16 @@ class FileStorageTests(FullGenericTests):
         self.assertEquals(self._expected_interfaces,
             self._storage._info['interfaces']
             )
+
+    @property
+    def _db(self):
+        self.__dict__['_db'] = db = ZODB.DB(self._storage)
+        def tearDown():
+            self._db.close()
+            del self.tearDown
+            self.tearDown()
+        self.tearDown = tearDown
+        return db
 
 class FileStorageSSLTests(FileStorageTests):
 


### PR DESCRIPTION
testZODB from ZODB is another set of generic tests that can be reused to check storage implementations. NEO runs them.

Note sure if ZODBTests is pertinent for any storage behind ZEO so I suggest to only add it to `FileStorageTests`. And contrary to other tests, ZODBTests expects a DB object as a `_db` attribute of the test case, hence the hacky property.

More generally, it would be good to review the ZODB test suite so that at least, storage implementations don't miss generic tests.