### PR TITLE
Make all classes new-style. This is especially good for PyPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ matrix:
         - os: linux
           python: 2.7
         - os: linux
+          python: pypy-5.4.1
+        - os: linux
           python: 3.4
         - os: linux
           python: 3.5

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 5.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- All classes are new-style classes on Python 2 (they were already
+  new-style on Python 3). This improves performance on PyPy. See
+  `issue 86 <<https://github.com/zopefoundation/ZEO/pull/86>`_.
 
 
 5.1.0 (2017-04-03)

--- a/src/ZEO/StorageServer.py
+++ b/src/ZEO/StorageServer.py
@@ -75,7 +75,7 @@ registered_methods = set(( 'get_info', 'lastTransaction',
     'iterator_next', 'iterator_record_start', 'iterator_record_next',
     'iterator_gc', 'server_status', 'set_client_label', 'ping'))
 
-class ZEOStorage:
+class ZEOStorage(object):
     """Proxy to underlying storage for a single remote client."""
 
     connected = connection = stats = storage = storage_id = transaction = None
@@ -616,7 +616,7 @@ class ZEOStorage:
     def ping(self):
         pass
 
-class StorageServerDB:
+class StorageServerDB(object):
     """Adapter from StorageServerDB to ZODB.interfaces.IStorageWrapper
 
     This is used in a ZEO fan-out situation, where a storage server
@@ -642,7 +642,7 @@ class StorageServerDB:
 
     transform_record_data = untransform_record_data = lambda self, data: data
 
-class StorageServer:
+class StorageServer(object):
 
     """The server side implementation of ZEO.
 
@@ -952,7 +952,7 @@ class StorageServer:
         return dict((storage_id, self.server_status(storage_id))
                     for storage_id in self.storages)
 
-class StubTimeoutThread:
+class StubTimeoutThread(object):
 
     def begin(self, client):
         pass
@@ -1067,7 +1067,7 @@ def _addr_label(addr):
         host, port = addr
         return str(host) + ":" + str(port)
 
-class CommitLog:
+class CommitLog(object):
 
     def __init__(self):
         self.file = tempfile.TemporaryFile(suffix=".comit-log")
@@ -1109,7 +1109,7 @@ class CommitLog:
             self.file.close()
             self.file = None
 
-class ServerEvent:
+class ServerEvent(object):
 
     def __init__(self, server, **kw):
         self.__dict__.update(kw)

--- a/src/ZEO/TransactionBuffer.py
+++ b/src/ZEO/TransactionBuffer.py
@@ -27,7 +27,7 @@ import ZODB.blob
 
 from ZEO._compat import Pickler, Unpickler
 
-class TransactionBuffer:
+class TransactionBuffer(object):
 
     # The TransactionBuffer is used by client storage to hold update
     # data until the tpc_finish().  It is only used by a single

--- a/src/ZEO/monitor.py
+++ b/src/ZEO/monitor.py
@@ -47,7 +47,7 @@ else:
     if zeo_dist is not None:
         zeo_version = zeo_dist.version
 
-class StorageStats:
+class StorageStats(object):
     """Per-storage usage statistics."""
 
     def __init__(self, connections=None):

--- a/src/ZEO/runzeo.py
+++ b/src/ZEO/runzeo.py
@@ -63,7 +63,7 @@ def windows_shutdown_handler():
     import asyncore
     asyncore.close_all()
 
-class ZEOOptionsMixin:
+class ZEOOptionsMixin(object):
 
     storages = None
 
@@ -72,7 +72,7 @@ class ZEOOptionsMixin:
 
     def handle_filename(self, arg):
         from ZODB.config import FileStorage # That's a FileStorage *opener*!
-        class FSConfig:
+        class FSConfig(object):
             def __init__(self, name, path):
                 self._name = name
                 self.path = path
@@ -138,7 +138,7 @@ class ZEOOptions(ZDOptions, ZEOOptionsMixin):
                     break
 
 
-class ZEOServer:
+class ZEOServer(object):
 
     def __init__(self, options):
         self.options = options

--- a/src/ZEO/scripts/parsezeolog.py
+++ b/src/ZEO/scripts/parsezeolog.py
@@ -47,7 +47,7 @@ def parse_line(line):
     m = meth_name, tuple(meth_args)
     return t, m
 
-class TStats:
+class TStats(object):
 
     counter = 1
 
@@ -73,7 +73,7 @@ class TStats:
         print(self.fmt % (time.ctime(self.begin), d_vote, d_finish,
                           self.user, self.url))
 
-class TransactionParser:
+class TransactionParser(object):
 
     def __init__(self):
         self.txns = {}

--- a/src/ZEO/scripts/zeoqueue.py
+++ b/src/ZEO/scripts/zeoqueue.py
@@ -79,7 +79,7 @@ def parse_time(line):
     return int(time.mktime(date_l + time_l + [0, 0, 0]))
 
 
-class Txn:
+class Txn(object):
     """Track status of single transaction."""
     def __init__(self, tid):
         self.tid = tid
@@ -98,7 +98,7 @@ class Txn:
 
 
 
-class Status:
+class Status(object):
     """Track status of ZEO server by replaying log records.
 
     We want to keep track of several events:

--- a/src/ZEO/scripts/zeoreplay.py
+++ b/src/ZEO/scripts/zeoreplay.py
@@ -96,7 +96,7 @@ def parse_line(line):
 
 
 
-class StoreStat:
+class StoreStat(object):
     def __init__(self, when, oid, size):
         self.when = when
         self.oid = oid
@@ -109,7 +109,7 @@ class StoreStat:
         raise IndexError
 
 
-class TxnStat:
+class TxnStat(object):
     def __init__(self):
         self._begintime = None
         self._finishtime = None
@@ -173,7 +173,7 @@ class ReplayTxn(TxnStat):
 
 
 
-class ZEOParser:
+class ZEOParser(object):
     def __init__(self, maxtxns=-1, report=1, storage=None):
         self.__txns = []
         self.__curtxn = {}

--- a/src/ZEO/tests/Cache.py
+++ b/src/ZEO/tests/Cache.py
@@ -17,7 +17,7 @@ from ZODB.Connection import TransactionMetaData
 from ZODB.tests.MinPO import MinPO
 from ZODB.tests.StorageTestBase import zodb_unpickle
 
-class TransUndoStorageWithCache:
+class TransUndoStorageWithCache(object):
 
     def checkUndoInvalidation(self):
         oid = self._storage.new_oid()

--- a/src/ZEO/tests/CommitLockTests.py
+++ b/src/ZEO/tests/CommitLockTests.py
@@ -26,7 +26,7 @@ from ZEO.tests.TestThread import TestThread
 
 ZERO = b'\0'*8
 
-class DummyDB:
+class DummyDB(object):
     def invalidate(self, *args, **kwargs):
         pass
 
@@ -68,7 +68,7 @@ class WorkerThread(TestThread):
         self.ready.set()
         future.result(9)
 
-class CommitLockTests:
+class CommitLockTests(object):
 
     NUM_CLIENTS = 5
 

--- a/src/ZEO/tests/ConnectionTests.py
+++ b/src/ZEO/tests/ConnectionTests.py
@@ -51,7 +51,7 @@ class TestClientStorage(ClientStorage):
         self.connection_count_for_tests += 1
         self.verify_result = conn.verify_result
 
-class DummyDB:
+class DummyDB(object):
     def invalidate(self, *args, **kwargs):
         pass
 
@@ -416,7 +416,7 @@ class ConnectionTests(CommonSetupTearDown):
     def checkBadMessage2(self):
         # just like a real message, but with an unpicklable argument
         global Hack
-        class Hack:
+        class Hack(object):
             pass
 
         msg = encode(1, 0, "foo", (Hack(),))
@@ -1106,7 +1106,7 @@ try:
 except (socket.error, AttributeError):
     pass
 else:
-    class V6Setup:
+    class V6Setup(object):
         def _getAddr(self):
             return '::1', forker.get_port(self)
 

--- a/src/ZEO/tests/InvalidationTests.py
+++ b/src/ZEO/tests/InvalidationTests.py
@@ -59,7 +59,7 @@ class FailableThread(TestThread):
             raise
 
 
-class StressTask:
+class StressTask(object):
     # Append integers startnum, startnum + step, startnum + 2*step, ...
     # to 'tree'.  If sleep is given, sleep
     # that long after each append.  At the end, instance var .added_keys
@@ -234,7 +234,7 @@ class LargeUpdatesThread(FailableThread):
         self.added_keys = keys_added.keys()
         cn.close()
 
-class InvalidationTests:
+class InvalidationTests(object):
 
     # Minimum # of seconds the main thread lets the workers run.  The
     # test stops as soon as this much time has elapsed, and all threads

--- a/src/ZEO/tests/IterationTests.py
+++ b/src/ZEO/tests/IterationTests.py
@@ -21,7 +21,7 @@ from ZODB.Connection import TransactionMetaData
 
 from ..asyncio.testing import AsyncRPC
 
-class IterationTests:
+class IterationTests(object):
 
     def _assertIteratorIdsEmpty(self):
         # Account for the need to run a GC collection

--- a/src/ZEO/tests/ThreadTests.py
+++ b/src/ZEO/tests/ThreadTests.py
@@ -71,7 +71,7 @@ class GetsThroughBeginThread(BasicThread):
             self.gotValueError = 1
 
 
-class ThreadTests:
+class ThreadTests(object):
     # Thread 1 should start a transaction, but not get all the way through it.
     # Main thread should close the connection.  Thread 1 should then get
     # disconnected.

--- a/src/ZEO/tests/ZEO4/StorageServer.py
+++ b/src/ZEO/tests/ZEO4/StorageServer.py
@@ -64,7 +64,7 @@ class StorageServerError(StorageError):
     """Error reported when an unpicklable exception is raised."""
 
 
-class ZEOStorage:
+class ZEOStorage(object):
     """Proxy to underlying storage for a single remote client."""
 
     # A list of extension methods.  A subclass with extra methods
@@ -758,7 +758,7 @@ class ZEOStorage:
     def set_client_label(self, label):
         self.log_label = str(label)+' '+_addr_label(self.connection.addr)
 
-class StorageServerDB:
+class StorageServerDB(object):
 
     def __init__(self, server, storage_id):
         self.server = server
@@ -776,7 +776,7 @@ class StorageServerDB:
 
     transform_record_data = untransform_record_data = lambda self, data: data
 
-class StorageServer:
+class StorageServer(object):
 
     """The server side implementation of ZEO.
 
@@ -1328,7 +1328,7 @@ def _level_for_waiting(waiting):
     else:
         return logging.DEBUG
 
-class StubTimeoutThread:
+class StubTimeoutThread(object):
 
     def begin(self, client):
         pass
@@ -1434,7 +1434,7 @@ class SlowMethodThread(threading.Thread):
             self.delay.reply(result)
 
 
-class ClientStub:
+class ClientStub(object):
 
     def __init__(self, rpc):
         self.rpc = rpc
@@ -1494,7 +1494,7 @@ class ClientStub308(ClientStub):
     def invalidateVerify(self, oid):
         ClientStub.invalidateVerify(self, (oid, ''))
 
-class ZEOStorage308Adapter:
+class ZEOStorage308Adapter(object):
 
     def __init__(self, storage):
         self.storage = storage
@@ -1582,7 +1582,7 @@ def _addr_label(addr):
         host, port = addr
         return str(host) + ":" + str(port)
 
-class CommitLog:
+class CommitLog(object):
 
     def __init__(self):
         self.file = tempfile.TemporaryFile(suffix=".comit-log")
@@ -1624,7 +1624,7 @@ class CommitLog:
             self.file.close()
             self.file = None
 
-class ServerEvent:
+class ServerEvent(object):
 
     def __init__(self, server, **kw):
         self.__dict__.update(kw)

--- a/src/ZEO/tests/ZEO4/auth/base.py
+++ b/src/ZEO/tests/ZEO4/auth/base.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import os
 from ..hash import sha1
 
-class Client:
+class Client(object):
     # Subclass should override to list the names of methods that
     # will be called on the server.
     extensions = []
@@ -37,7 +37,7 @@ def sort(L):
     L.sort()
     return L
 
-class Database:
+class Database(object):
     """Abstracts a password database.
 
     This class is used both in the authentication process (via

--- a/src/ZEO/tests/ZEO4/auth/hmac.py
+++ b/src/ZEO/tests/ZEO4/auth/hmac.py
@@ -14,7 +14,7 @@ def _strxor(s1, s2):
 # hashing module used.
 digest_size = None
 
-class HMAC:
+class HMAC(object):
     """RFC2104 HMAC class.
 
     This supports the API for Cryptographic Hash Functions (PEP 247).

--- a/src/ZEO/tests/ZEO4/monitor.py
+++ b/src/ZEO/tests/ZEO4/monitor.py
@@ -47,7 +47,7 @@ else:
     if zeo_dist is not None:
         zeo_version = zeo_dist.version
 
-class StorageStats:
+class StorageStats(object):
     """Per-storage usage statistics."""
 
     def __init__(self, connections=None):

--- a/src/ZEO/tests/ZEO4/runzeo.py
+++ b/src/ZEO/tests/ZEO4/runzeo.py
@@ -64,7 +64,7 @@ def windows_shutdown_handler():
     import asyncore
     asyncore.close_all()
 
-class ZEOOptionsMixin:
+class ZEOOptionsMixin(object):
 
     storages = None
 
@@ -76,7 +76,7 @@ class ZEOOptionsMixin:
 
     def handle_filename(self, arg):
         from ZODB.config import FileStorage # That's a FileStorage *opener*!
-        class FSConfig:
+        class FSConfig(object):
             def __init__(self, name, path):
                 self._name = name
                 self.path = path
@@ -145,7 +145,7 @@ class ZEOOptions(ZDOptions, ZEOOptionsMixin):
                     break
 
 
-class ZEOServer:
+class ZEOServer(object):
 
     def __init__(self, options):
         self.options = options

--- a/src/ZEO/tests/ZEO4/zrpc/_hmac.py
+++ b/src/ZEO/tests/ZEO4/zrpc/_hmac.py
@@ -17,7 +17,7 @@ def _strxor(s1, s2):
 # hashing module used.
 digest_size = None
 
-class HMAC:
+class HMAC(object):
     """RFC2104 HMAC class.
 
     This supports the API for Cryptographic Hash Functions (PEP 247).

--- a/src/ZEO/tests/ZEO4/zrpc/client.py
+++ b/src/ZEO/tests/ZEO4/zrpc/client.py
@@ -536,7 +536,7 @@ class ConnectThread(threading.Thread):
             # TODO: should check deadline
 
 
-class ConnectWrapper:
+class ConnectWrapper(object):
     """An object that handles the connection procedure for one socket.
 
     This is a little state machine with states:

--- a/src/ZEO/tests/ZEO4/zrpc/connection.py
+++ b/src/ZEO/tests/ZEO4/zrpc/connection.py
@@ -32,7 +32,7 @@ exception_type_type = type(Exception)
 
 debug_zrpc = False
 
-class Delay:
+class Delay(object):
     """Used to delay response to client for synchronous calls.
 
     When a synchronous call is made and the original handler returns

--- a/src/ZEO/tests/forker.py
+++ b/src/ZEO/tests/forker.py
@@ -41,7 +41,7 @@ skip_if_testing_client_against_zeo4 = (
     (lambda func: func)
     )
 
-class ZEOConfig:
+class ZEOConfig(object):
     """Class to generate ZEO configuration file. """
 
     def __init__(self, addr, log=None, **options):

--- a/src/ZEO/tests/testConnection.py
+++ b/src/ZEO/tests/testConnection.py
@@ -33,7 +33,7 @@ import ZEO
 
 from . import forker
 
-class FileStorageConfig:
+class FileStorageConfig(object):
     def getConfig(self, path, create, read_only):
         return """\
         <filestorage 1>
@@ -44,7 +44,7 @@ class FileStorageConfig:
                              create and 'yes' or 'no',
                              read_only and 'yes' or 'no')
 
-class MappingStorageConfig:
+class MappingStorageConfig(object):
     def getConfig(self, path, create, read_only):
         return """<mappingstorage 1/>"""
 

--- a/src/ZEO/tests/testConversionSupport.py
+++ b/src/ZEO/tests/testConversionSupport.py
@@ -16,7 +16,7 @@ import unittest
 
 import ZEO.asyncio.testing
 
-class FakeStorageBase:
+class FakeStorageBase(object):
 
     def __getattr__(self, name):
         if name in ('getTid', 'history', 'load', 'loadSerial',
@@ -43,7 +43,7 @@ class FakeStorage(FakeStorageBase):
 
         return oid, oid*8, 'data ' + oid, next
 
-class FakeServer:
+class FakeServer(object):
     storages = {
         '1': FakeStorage(),
         '2': FakeStorageBase(),
@@ -55,7 +55,7 @@ class FakeServer:
 
     client_conflict_resolution = False
 
-class FakeConnection:
+class FakeConnection(object):
     protocol_version = b'Z4'
     addr = 'test'
 

--- a/src/ZEO/tests/testZEO.py
+++ b/src/ZEO/tests/testZEO.py
@@ -61,7 +61,7 @@ from . import testssl
 
 logger = logging.getLogger('ZEO.tests.testZEO')
 
-class DummyDB:
+class DummyDB(object):
     def invalidate(self, *args):
         pass
     def invalidateCache(*unused):
@@ -75,7 +75,7 @@ class CreativeGetState(persistent.Persistent):
         return super(CreativeGetState, self).__getstate__()
 
 
-class MiscZEOTests:
+class MiscZEOTests(object):
     """ZEO tests that don't fit in elsewhere."""
 
     def checkCreativeGetState(self):
@@ -490,7 +490,7 @@ class ZRPCConnectionTests(ZEO.tests.ConnectionTests.CommonSetupTearDown):
         self._storage = storage
         assert storage.is_connected()
 
-        class DummyDB:
+        class DummyDB(object):
             _invalidatedCache = 0
             def invalidateCache(self):
                 self._invalidatedCache += 1
@@ -522,7 +522,7 @@ class ZRPCConnectionTests(ZEO.tests.ConnectionTests.CommonSetupTearDown):
         self.assertEqual(db._invalidatedCache, base+1)
 
 
-class CommonBlobTests:
+class CommonBlobTests(object):
 
     def getConfig(self):
         return """
@@ -706,7 +706,7 @@ class BlobWritableCacheTests(FullGenericTests, CommonBlobTests):
     blob_cache_dir = 'blobs'
     shared_blob_dir = True
 
-class FauxConn:
+class FauxConn(object):
     addr = 'x'
     protocol_version = ZEO.asyncio.server.best_protocol_version
     peer_protocol_version = protocol_version
@@ -718,7 +718,7 @@ class FauxConn:
 
     call_soon_threadsafe = async_threadsafe = async
 
-class StorageServerWrapper:
+class StorageServerWrapper(object):
 
     def __init__(self, server, storage_id):
         self.storage_id = storage_id

--- a/src/ZEO/tests/testZEO2.py
+++ b/src/ZEO/tests/testZEO2.py
@@ -75,7 +75,7 @@ will conflict. It will be blocked at the vote call.
     >>> zs2.storeBlobEnd(oid, serial, data, '1')
     >>> delay = zs2.vote('1')
 
-    >>> class Sender:
+    >>> class Sender(object):
     ...     def send_reply(self, id, reply):
     ...         print('reply', id, reply)
     ...     def send_error(self, id, err):

--- a/src/ZEO/tests/testZEOServer.py
+++ b/src/ZEO/tests/testZEOServer.py
@@ -7,7 +7,7 @@ import unittest
 from ZEO.runzeo import ZEOServer
 
 
-class TestStorageServer:
+class TestStorageServer(object):
 
     def __init__(self, fail_create_server):
         self.called = []

--- a/src/ZEO/tests/utils.py
+++ b/src/ZEO/tests/utils.py
@@ -3,7 +3,7 @@
 import ZEO.StorageServer
 from ..asyncio.server import best_protocol_version
 
-class ServerProtocol:
+class ServerProtocol(object):
 
     method = ('register', )
 
@@ -30,7 +30,7 @@ class ServerProtocol:
 
     async_threadsafe = async
 
-class StorageServer:
+class StorageServer(object):
     """Create a client interface to a StorageServer.
 
     This is for testing StorageServer. It interacts with the storgr

--- a/src/ZEO/util.py
+++ b/src/ZEO/util.py
@@ -25,7 +25,7 @@ def parentdir(p, n=1):
         n -= 1
     return d
 
-class Environment:
+class Environment(object):
     """Determine location of the Data.fs & ZEO_SERVER.pid files.
 
     Pass the argv[0] used to start ZEO to the constructor.

--- a/src/ZEO/zconfig.py
+++ b/src/ZEO/zconfig.py
@@ -49,7 +49,7 @@ def server_ssl(section):
 def client_ssl(section):
     return ssl_config(section, False)
 
-class ClientStorageConfig:
+class ClientStorageConfig(object):
 
     def __init__(self, config):
         self.config = config


### PR DESCRIPTION
See https://github.com/zopefoundation/ZODB/pull/160 for rationale.

Also restore PyPy to the build matrix.

I didn't try too hard to benchmark the actual improvements because there's a bug in the latest PyPy's (5.7.1) jit (I presume) that caused crashes (even with ZEO 4) under heavy loads (mostly on the client in ZEO5, mostly on the server in ZEO 4, interestingly enough). I did verify that under light load it at least performed no worse than before, both with and without zopefoundation/ZODB#160 being applied.