### PR TITLE
fix ZopeUndo.Prefix decode on python 2

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -13,6 +13,8 @@ extra =
 recipe = zc.recipe.testrunner
 eggs =
     ZEO [test${buildout:extra}]
+# ZopeUndo is needed as soft-dependency for a regression test
+    ZopeUndo
 initialization =
   import os, tempfile
   try: os.mkdir('tmp')

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ tests_require = [
     'random2',
     'mock',
     'msgpack-python',
-    'ZopeUndo',
 ]
 
 classifiers = """

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ tests_require = [
     'random2',
     'mock',
     'msgpack-python',
+    'ZopeUndo',
 ]
 
 classifiers = """

--- a/src/ZEO/asyncio/marshal.py
+++ b/src/ZEO/asyncio/marshal.py
@@ -157,7 +157,7 @@ def find_global(module, name):
 def server_find_global(module, name):
     """Helper for message unpickler"""
     try:
-        if module != 'ZopeUndo.Prefix':
+        if module not in ('ZopeUndo.Prefix', 'copy_reg', '__builtin__'):
             raise ImportError
         m = __import__(module, _globals, _globals, _silly)
     except ImportError as msg:

--- a/src/ZEO/tests/test_marshal.py
+++ b/src/ZEO/tests/test_marshal.py
@@ -7,7 +7,10 @@ from ZopeUndo.Prefix import Prefix
 class MarshalTests(unittest.TestCase):
 
     def testServerDecodeZopeUndoFilter(self):
-        # this is an example of Zope's 
+        # this is an example (1) of Zope2's arguments for
+        # undoInfo call. Arguments are encoded by ZEO client
+        # and decoded by server. The operation must be idempotent.
+        # (1) https://github.com/zopefoundation/Zope/blob/2.13/src/App/Undo.py#L111
         args = (0, 20, {'user_name': Prefix('test')})
         # test against repr because Prefix __eq__ operator
         # doesn't compare Prefix with Prefix but only

--- a/src/ZEO/tests/test_marshal.py
+++ b/src/ZEO/tests/test_marshal.py
@@ -1,11 +1,18 @@
 import unittest
 from ZEO.asyncio.marshal import encode
 from ZEO.asyncio.marshal import pickle_server_decode
-from ZopeUndo.Prefix import Prefix
+
+try:
+    from ZopeUndo.Prefix import Prefix
+except ImportError:
+    _HAVE_ZOPE_UNDO = False
+else:
+    _HAVE_ZOPE_UNDO = True
 
 
 class MarshalTests(unittest.TestCase):
 
+    @unittest.skipUnless(_HAVE_ZOPE_UNDO)
     def testServerDecodeZopeUndoFilter(self):
         # this is an example (1) of Zope2's arguments for
         # undoInfo call. Arguments are encoded by ZEO client
@@ -25,4 +32,3 @@ def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(MarshalTests))
     return suite
-

--- a/src/ZEO/tests/test_marshal.py
+++ b/src/ZEO/tests/test_marshal.py
@@ -1,0 +1,25 @@
+import unittest
+from ZEO.asyncio.marshal import encode
+from ZEO.asyncio.marshal import pickle_server_decode
+from ZopeUndo.Prefix import Prefix
+
+
+class MarshalTests(unittest.TestCase):
+
+    def testServerDecodeZopeUndoFilter(self):
+        # this is an example of Zope's 
+        args = (0, 20, {'user_name': Prefix('test')})
+        # test against repr because Prefix __eq__ operator
+        # doesn't compare Prefix with Prefix but only
+        # Prefix with strings. see Prefix.__doc__
+        self.assertEqual(
+            repr(pickle_server_decode(encode(*args))),
+            repr(args)
+        )
+
+
+def test_suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(MarshalTests))
+    return suite
+

--- a/src/ZEO/tests/test_marshal.py
+++ b/src/ZEO/tests/test_marshal.py
@@ -12,7 +12,7 @@ else:
 
 class MarshalTests(unittest.TestCase):
 
-    @unittest.skipUnless(_HAVE_ZOPE_UNDO)
+    @unittest.skipUnless(_HAVE_ZOPE_UNDO, 'ZopeUndo is not installed')
     def testServerDecodeZopeUndoFilter(self):
         # this is an example (1) of Zope2's arguments for
         # undoInfo call. Arguments are encoded by ZEO client

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,8 @@ deps =
     zope.testing
     zope.testrunner
     mock
-
+# ZopeUndo is needed as soft-dependency for a regression test
+    ZopeUndo
 [testenv:simple]
 # Test that 'setup.py test' works
 basepython =


### PR DESCRIPTION
On python 2, calling undoLog via ZEO with ZopeUndo.Prefix filter, ZEO server raise an exception:

```
File ".../src/ZEO/asyncio/marshal.py", line 114, in pickle_server_decode
    return unpickler.load() # msgid, flags, name, args
File ".../src/ZEO/asyncio/marshal.py", line 164, in server_find_global
    raise ImportError("import error %s: %s" % (module, msg))
ImportError: import error copy_reg:
```

The problem was introduced when ZopeUndo.Prefix was changed and subclassed from the object.

This PR tries to fix the problem.