### PR TITLE
Return early after decode error.

### DIFF
--- a/src/ZEO/asyncio/server.py
+++ b/src/ZEO/asyncio/server.py
@@ -90,6 +90,7 @@ class ServerProtocol(base.Protocol):
         except Exception:
             logger.exception("Can't deserialize message")
             self.close()
+            return
 
         if message_id == -1:
             return # keep-alive


### PR DESCRIPTION
Closes #107.

@jimfulton I couldn't figure the testing story out well enough to write a simple test for this case, but returning early after closing the server protocol seems right by inspection.