### PR TITLE
Disallow using strings as addresses on Windows. Fixes #106.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ Changelog
 - Fix ``ZEO.server`` relying on test dependencies. See `issue 105
   <https://github.com/zopefoundation/ZEO/issues/105>`_.
 
+- Disallow passing strings as addresses to ClientStorage under Windows
+  because string addresses are used for unix-domain sockets, which
+  aren't supported on Windows. See `issue 107
+  <https://github.com/zopefoundation/ZEO/issues/107>`_.
 
 5.1.2 (2018-03-27)
 ------------------

--- a/src/ZEO/ClientStorage.py
+++ b/src/ZEO/ClientStorage.py
@@ -41,6 +41,7 @@ import six
 
 from persistent.TimeStamp import TimeStamp
 from ZEO._compat import get_ident
+from ZEO._compat import WIN
 from ZEO.Exceptions import ClientDisconnected
 from ZEO.TransactionBuffer import TransactionBuffer
 from ZODB import POSException
@@ -191,6 +192,8 @@ class ClientStorage(ZODB.ConflictResolution.ConflictResolvingStorage):
         self.__name__ = name or str(addr) # Standard convention for storages
 
         if isinstance(addr, six.string_types):
+            if WIN:
+                raise ValueError("Unix sockets are not available on Windows")
             addr = [addr]
         elif (isinstance(addr, tuple) and len(addr) == 2 and
               isinstance(addr[0], six.string_types) and isinstance(addr[1], int)):

--- a/src/ZEO/_compat.py
+++ b/src/ZEO/_compat.py
@@ -19,6 +19,7 @@ import platform
 PY3 = sys.version_info[0] >= 3
 PY32 = sys.version_info[:2] == (3, 2)
 PYPY = getattr(platform, 'python_implementation', lambda: None)() == 'PyPy'
+WIN = sys.platform.startswith('win')
 
 if PY3:
     from pickle import Pickler, Unpickler as _Unpickler, dump, dumps, loads

--- a/src/ZEO/tests/forker.py
+++ b/src/ZEO/tests/forker.py
@@ -29,6 +29,7 @@ import six
 import ZODB.tests.util
 import zope.testing.setupstack
 
+from ZEO._compat import WIN
 from ZEO import _forker
 
 logger = logging.getLogger('ZEO.tests.forker')
@@ -60,7 +61,7 @@ runner = _forker.runner
 stop_runner = _forker.stop_runner
 start_zeo_server = _forker.start_zeo_server
 
-if sys.platform[:3].lower() == "win":
+if WIN:
     def _quote_arg(s):
         return '"%s"' % s
 else:

--- a/src/ZEO/tests/testZEO.py
+++ b/src/ZEO/tests/testZEO.py
@@ -20,6 +20,7 @@ from ZEO.ClientStorage import ClientStorage
 from ZEO.tests import forker, Cache, CommitLockTests, ThreadTests
 from ZEO.tests import IterationTests
 from ZEO._compat import PY3
+from ZEO._compat import WIN
 
 from ZODB.Connection import TransactionMetaData
 from ZODB.tests import StorageTestBase, BasicStorage,  \
@@ -1583,7 +1584,7 @@ if not os.environ.get('ZEO4_SERVER'):
             >>> conn.close(); s()
             """
 
-if sys.platform.startswith('win'):
+if WIN:
     del runzeo_logrotate_on_sigusr2
     del unix_domain_sockets
 


### PR DESCRIPTION
No specific test case, though.