### PR TITLE
Use pickle protocol 3 on the wire.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-5.1.3 (unreleased)
+5.2.0 (unreleased)
 ------------------
 
 - Fix ``ZEO.server`` relying on test dependencies. See `issue 105
@@ -19,6 +19,10 @@ Changelog
 - Fix: Client-side updates for ZODB 5.4.0 or databases that already
   had ``zodbpickle.binary`` OIDs. See `issue 113
   <https://github.com/zopefoundation/ZEO/issues/113>`_.
+
+- ZEO now uses pickle protocol 3 for both Python 2 and Python 3.
+  (Previously protocol 1 was used for Python 2.) This matches the
+  change in ZODB 5.4.0.
 
 5.1.2 (2018-03-27)
 ------------------

--- a/src/ZEO/_compat.py
+++ b/src/ZEO/_compat.py
@@ -22,7 +22,7 @@ PYPY = getattr(platform, 'python_implementation', lambda: None)() == 'PyPy'
 WIN = sys.platform.startswith('win')
 
 if PY3:
-    from pickle import Pickler, Unpickler as _Unpickler, dump, dumps, loads
+    from zodbpickle.pickle import Pickler, Unpickler as _Unpickler, dump, dumps, loads
     class Unpickler(_Unpickler):
         # Py3: Python 3 doesn't allow assignments to find_global,
         # instead, find_class can be overridden
@@ -34,8 +34,15 @@ if PY3:
                 return super(Unpickler, self).find_class(modulename, name)
             return self.find_global(modulename, name)
 else:
-    # Pickle support
-    from cPickle import Pickler, Unpickler, dump, dumps, loads
+    try:
+        import zodbpickle.fastpickle as cPickle
+    except ImportError:
+        import zodbpickle.pickle as cPickle
+    Pickler = cPickle.Pickler
+    Unpickler = cPickle.Unpickler
+    dump = cPickle.dump
+    dumps = cPickle.dumps
+    loads = cPickle.loads
 
 # String and Bytes IO
 from ZODB._compat import BytesIO

--- a/src/ZEO/asyncio/marshal.py
+++ b/src/ZEO/asyncio/marshal.py
@@ -42,25 +42,18 @@ def encoder(protocol, server=False):
     else:
         assert protocol[:1] == b'Z'
 
-    if PY3 or PYPY:
-        f = BytesIO()
-        getvalue = f.getvalue
-        seek = f.seek
-        truncate = f.truncate
-        pickler = Pickler(f, 3 if PY3 else 1)
-        pickler.fast = 1
-        dump = pickler.dump
-        def encode(*args):
-            seek(0)
-            truncate()
-            dump(args)
-            return getvalue()
-    else:
-        pickler = Pickler(1)
-        pickler.fast = 1
-        dump = pickler.dump
-        def encode(*args):
-            return dump(args, 2)
+    f = BytesIO()
+    getvalue = f.getvalue
+    seek = f.seek
+    truncate = f.truncate
+    pickler = Pickler(f, 3)
+    pickler.fast = 1
+    dump = pickler.dump
+    def encode(*args):
+        seek(0)
+        truncate()
+        dump(args)
+        return getvalue()
 
     return encode
 

--- a/src/ZEO/tests/ZEO4/zrpc/marshal.py
+++ b/src/ZEO/tests/ZEO4/zrpc/marshal.py
@@ -32,24 +32,13 @@ def encode(*args): # args: (msgid, flags, name, args)
     # being represented by \xij escapes in proto 0).
     # Undocumented:  cPickle.Pickler accepts a lone protocol argument;
     # pickle.py does not.
-    if PY3:
-        # XXX: Py3: Needs optimization.
-        f = BytesIO()
-        pickler = Pickler(f, 3)
-        pickler.fast = 1
-        pickler.dump(args)
-        res = f.getvalue()
-        return res
-    else:
-        pickler = Pickler(1)
-        pickler.fast = 1
-        # Only CPython's cPickle supports dumping
-        # and returning in one operation:
-        #   return pickler.dump(args, 1)
-        # For PyPy we must return the value; fortunately this
-        # works the same on CPython and is no more expensive
-        pickler.dump(args)
-        return pickler.getvalue()
+    # XXX: Py3: Needs optimization.
+    f = BytesIO()
+    pickler = Pickler(f, 3)
+    pickler.fast = 1
+    pickler.dump(args)
+    res = f.getvalue()
+    return res
 
 
 

--- a/src/ZEO/tests/testZEO.py
+++ b/src/ZEO/tests/testZEO.py
@@ -487,7 +487,9 @@ class ClientConflictResolutionTests(
         return '<mappingstorage>\n</mappingstorage>\n'
 
     def getZEOConfig(self):
-        return forker.ZEOConfig(('', 0), client_conflict_resolution=True)
+        # Using '' can result in binding to :: and cause problems
+        # connecting to the MTAcceptor on Travis CI
+        return forker.ZEOConfig(('127.0.0.1', 0), client_conflict_resolution=True)
 
 class MappingStorageTests(GenericTests):
     """ZEO backed by a Mapping storage."""


### PR DESCRIPTION
I also snuck the fix for ZEO_MTACCEPTOR tests in (use IPv4 instead of v6), so we have green builds (🙌 ).

On Python 2, this will necessitate that the client and server are both running at least this version of ZEO (because before this, ZEO wasn't using zodbpickle to read the wire so they won't be able to decode the protocol). Or use msgpack.