### PR TITLE
'msgpack-python' egg was renamed 'msgpack'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changelog
 
 - Add support for Python 3.7.
 
+- Switch from `msgpack-python` to `msgpack`. Currently a version < 0.6
+  is required.
+
 
 5.2.0 (2018-03-28)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ tests_require = [
     'manuel',
     'random2',
     'mock',
-    'msgpack-python',
+    'msgpack',
     'zope.testrunner',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ tests_require = [
     'manuel',
     'random2',
     'mock',
-    'msgpack',
+    'msgpack < 0.6',
     'zope.testrunner',
 ]
 


### PR DESCRIPTION
https://github.com/msgpack/msgpack-python/#very-important-notes-for-existing-users