### PR TITLE
Use a temporary directory in tests

### DIFF
--- a/src/ZEO/tests/test_client_side_conflict_resolution.py
+++ b/src/ZEO/tests/test_client_side_conflict_resolution.py
@@ -1,10 +1,13 @@
+import os
+import shutil
+import tempfile
 import unittest
-import zope.testing.setupstack
 
+import zope.testing.setupstack
 from BTrees.Length import Length
 from ZODB import serialize
 from ZODB.DemoStorage import DemoStorage
-from ZODB.utils import p64, z64, maxtid
+from ZODB.utils import z64, maxtid
 from ZODB.broken import find_global
 
 import ZEO
@@ -111,7 +114,9 @@ class ClientSideConflictResolutionTests(zope.testing.setupstack.TestCase):
 
     def test_client_side(self):
         # First, traditional:
-        addr, stop = ZEO.server('data.fs', threaded=False)
+        path = tempfile.mkdtemp(prefix='zeo-test-')
+        self.addCleanup(shutil.rmtree, path)
+        addr, stop = ZEO.server(os.path.join(path, 'data.fs'), threaded=False)
         db = ZEO.DB(addr)
         with db.transaction() as conn:
             conn.root.l = Length(0)

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,9 @@ envlist =
 [testenv]
 commands =
 # Run unit tests first.
-    zope-testrunner -u --test-path=src --auto-color --auto-progress
+    zope-testrunner -u --test-path=src --auto-color --auto-progress {posargs}
 # Only run functional tests if unit tests pass.
-    zope-testrunner -f --test-path=src --auto-color --auto-progress
+    zope-testrunner -f --test-path=src --auto-color --auto-progress {posargs}
 deps =
     ZODB >= 4.2.0b1
     random2


### PR DESCRIPTION
Otherwise when you run `tox` this test will create a `data.fs` using Python 2 and then the same test will fail on Python 3 because there already is a `data.fs` in the current working directory, but it has an incompatible format.

See https://github.com/zopefoundation/ZEO/issues/140#issuecomment-486650942