### PR TITLE
Use of --configure option instead of --configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,7 +151,7 @@ Running the server
 Typically, the ZEO server is run using the ``runzeo`` script that's
 installed as part of a ZEO installation.  The ``runzeo`` script
 accepts command line options, the most important of which is the
-``-C`` (``--configuration``) option.  ZEO servers are best configured
+``-C`` (``--configure``) option.  ZEO servers are best configured
 via configuration files.  The ``runzeo`` script also accepts some
 command-line arguments for ad-hoc configurations, but there's an
 easier way to run an ad-hoc server described below.  For more on

--- a/src/ZEO/runzeo.py
+++ b/src/ZEO/runzeo.py
@@ -16,7 +16,7 @@
 Usage: %s [-C URL] [-a ADDRESS] [-f FILENAME] [-h]
 
 Options:
--C/--configuration URL -- configuration file or URL
+-C/--configure URL -- configuration file or URL
 -a/--address ADDRESS -- server address of the form PORT, HOST:PORT, or PATH
                         (a PATH must contain at least one "/")
 -f/--filename FILENAME -- filename for FileStorage

--- a/src/ZEO/tests/ZEO4/runzeo.py
+++ b/src/ZEO/tests/ZEO4/runzeo.py
@@ -16,7 +16,7 @@
 Usage: %s [-C URL] [-a ADDRESS] [-f FILENAME] [-h]
 
 Options:
--C/--configuration URL -- configuration file or URL
+-C/--configure URL -- configuration file or URL
 -a/--address ADDRESS -- server address of the form PORT, HOST:PORT, or PATH
                         (a PATH must contain at least one "/")
 -f/--filename FILENAME -- filename for FileStorage


### PR DESCRIPTION
So using `--help` option will show `--configure` option:

```
$ ./venv/bin/runzeo --help
Start the ZEO storage server.

Usage: ./venv/bin/runzeo [-C URL] [-a ADDRESS] [-f FILENAME] [-h]

Options:
-C/--configure URL -- configuration file or URL
[...]
```

`--configuration` don't work and `--configure` option seems to be more standard between Z-tools.

closes: #138
#138 provides more explanation about it.