### PR TITLE
Replace deprecated occurences of Thread.isAlive() by Thread.is_alive()

### DIFF
--- a/src/ZEO/StorageServer.py
+++ b/src/ZEO/StorageServer.py
@@ -939,7 +939,7 @@ class StorageServer(object):
         status['connections'] = len(status['connections'])
         lock_manager = self.lock_managers[storage_id]
         status['waiting'] = len(lock_manager.waiting)
-        status['timeout-thread-is-alive'] = lock_manager.timeout.isAlive()
+        status['timeout-thread-is-alive'] = lock_manager.timeout.is_alive()
         last_transaction = self.storages[storage_id].lastTransaction()
         last_transaction_hex = codecs.encode(last_transaction, 'hex_codec')
         if PY3:
@@ -960,7 +960,7 @@ class StubTimeoutThread(object):
     def end(self, client):
         pass
 
-    isAlive = lambda self: 'stub'
+    is_alive = lambda self: 'stub'
 
 
 class TimeoutThread(threading.Thread):

--- a/src/ZEO/tests/ConnectionTests.py
+++ b/src/ZEO/tests/ConnectionTests.py
@@ -493,7 +493,7 @@ class ConnectionTests(CommonSetupTearDown):
             # Wait for all threads to finish
             for t in threads:
                 t.join(60)
-                self.assertFalse(t.isAlive(), "%s didn't die" % t.getName())
+                self.assertFalse(t.is_alive(), "%s didn't die" % t.getName())
         finally:
             for t in threads:
                 t.closeclients()

--- a/src/ZEO/tests/TestThread.py
+++ b/src/ZEO/tests/TestThread.py
@@ -53,5 +53,5 @@ class TestThread(threading.Thread):
         self.join(timeout)
         if self._exc_info:
             six.reraise(self._exc_info[0], self._exc_info[1], self._exc_info[2])
-        if self.isAlive():
+        if self.is_alive():
             self._testcase.fail("Thread did not finish: %s" % self)

--- a/src/ZEO/tests/ThreadTests.py
+++ b/src/ZEO/tests/ThreadTests.py
@@ -34,7 +34,7 @@ class BasicThread(threading.Thread):
 
     def join(self):
         threading.Thread.join(self, 10)
-        assert not self.isAlive()
+        assert not self.is_alive()
 
 
 class GetsThroughVoteThread(BasicThread):
@@ -119,7 +119,7 @@ class ThreadTests(object):
         for t in threads:
             t.join(30)
         for i in threads:
-            self.assertFalse(t.isAlive())
+            self.assertFalse(t.is_alive())
 
     # Helper for checkMTStores
     def mtstorehelper(self):

--- a/src/ZEO/tests/ZEO4/StorageServer.py
+++ b/src/ZEO/tests/ZEO4/StorageServer.py
@@ -1307,7 +1307,7 @@ class StorageServer(object):
         status = self.stats[storage_id].__dict__.copy()
         status['connections'] = len(status['connections'])
         status['waiting'] = len(self._waiting[storage_id])
-        status['timeout-thread-is-alive'] = self.timeouts[storage_id].isAlive()
+        status['timeout-thread-is-alive'] = self.timeouts[storage_id].is_alive()
         last_transaction = self.storages[storage_id].lastTransaction()
         last_transaction_hex = codecs.encode(last_transaction, 'hex_codec')
         if PY3:
@@ -1336,7 +1336,7 @@ class StubTimeoutThread(object):
     def end(self, client):
         pass
 
-    isAlive = lambda self: 'stub'
+    is_alive = lambda self: 'stub'
 
 
 class TimeoutThread(threading.Thread):

--- a/src/ZEO/tests/ZEO4/zrpc/client.py
+++ b/src/ZEO/tests/ZEO4/zrpc/client.py
@@ -218,7 +218,7 @@ class ConnectionManager(object):
             log("CM.close(): stopping and joining thread")
             t.stop()
             t.join(30)
-            if t.isAlive():
+            if t.is_alive():
                 log("CM.close(): self.thread.join() timed out",
                     level=logging.WARNING)
 
@@ -288,7 +288,7 @@ class ConnectionManager(object):
                 t.setDaemon(1)
                 t.start()
             if sync:
-                while self.connection is None and t.isAlive():
+                while self.connection is None and t.is_alive():
                     self.cond.wait(self.sync_wait)
                     if self.connection is None:
                         log("CM.connect(sync=1): still waiting...")

--- a/src/ZEO/tests/testConnection.py
+++ b/src/ZEO/tests/testConnection.py
@@ -213,7 +213,7 @@ This tests tries to provoke this bug by:
     ...     stop = True
     ...     thread.join(10)
 
-    >>> thread.isAlive()
+    >>> thread.is_alive()
     False
 
     >>> for record in handler.records:

--- a/src/ZEO/tests/zeo_blob_cache.test
+++ b/src/ZEO/tests/zeo_blob_cache.test
@@ -136,7 +136,7 @@ provoke problems:
     ...     thread.start()
     >>> for thread in threads:
     ...     thread.join(99)
-    ...     if thread.isAlive():
+    ...     if thread.is_alive():
     ...        print("Can't join thread.")
 
     >>> wait_until("size is reduced", check, 99, onfail)


### PR DESCRIPTION
This PR replaces `Thread.isAlive()` calls by `Thread.is_alive()` calls because the first method is deprecated. 

Currently, several `PendingDeprecationWarning` are raised when `tox` runs:

`
  Set up .ZEO Connection DocTests in 0.003 seconds.
  Running:
    1/1 (100.0%)/home/stephane/src/ZEO/.tox/py37/lib/python3.7/site-packages/ZEO/tests/testConnection.py:1: PendingDeprecationWarning: isAlive() is deprecated, use is_alive() instead
`