### PR TITLE
[ZEO4] Include both modified and just created objects into invalidations

### DIFF
--- a/src/ZEO/StorageServer.py
+++ b/src/ZEO/StorageServer.py
@@ -406,6 +406,7 @@ class ZEOStorage:
 
         self.stats.commits += 1
         self.storage.tpc_finish(self.transaction, self._invalidate)
+        self.client.info(self.get_size_info())
         # Note that the tid is still current because we still hold the
         # commit lock. We'll relinquish it in _clear_transaction.
         tid = self.storage.lastTransaction()
@@ -414,8 +415,7 @@ class ZEOStorage:
 
     def _invalidate(self, tid):
         if self.invalidated:
-            self.server.invalidate(self, self.storage_id, tid,
-                                   self.invalidated, self.get_size_info())
+            self.server.invalidate(self, self.storage_id, tid, self.invalidated)
 
     def tpc_abort(self, tid):
         if not self._check_tid(tid):

--- a/src/ZEO/StorageServer.py
+++ b/src/ZEO/StorageServer.py
@@ -638,8 +638,7 @@ class ZEOStorage:
             self._op_error(oid, error, 'store')
             err = error
         else:
-            if serial != b"\0\0\0\0\0\0\0\0":
-                self.invalidated.append(oid)
+            self.invalidated.append(oid)
 
             if isinstance(newserial, bytes):
                 newserial = [(oid, newserial)]

--- a/src/ZEO/tests/servertesting.py
+++ b/src/ZEO/tests/servertesting.py
@@ -70,6 +70,7 @@ class Connection:
         print(self.name, 'callAsync', meth, repr(args))
 
     callAsyncNoPoll = callAsync
+    callAsyncNoSend = callAsync
 
     def call_from_thread(self, *args):
         if args:

--- a/src/ZEO/tests/testZEO.py
+++ b/src/ZEO/tests/testZEO.py
@@ -913,7 +913,7 @@ def multiple_storages_invalidation_queue_is_not_insane():
     >>> trans, oids = s1.getInvalidations(last)
     >>> from ZODB.utils import u64
     >>> sorted([int(u64(oid)) for oid in oids])
-    [10, 11, 12, 13, 14]
+    [10, 11, 12, 13, 14, 15]
 
     >>> server.close()
     """
@@ -970,15 +970,6 @@ structure using lastTransactions.
     >>> sorted([int(u64(oid)) for oid in oids])
     [0, 92, 93, 94, 95, 96, 97, 98, 99, 100]
 
-(Note that the fact that we get oids for 92-100 is actually an
-artifact of the fact that the FileStorage lastInvalidations method
-returns all OIDs written by transactions, even if the OIDs were
-created and not modified. FileStorages don't record whether objects
-were created rather than modified. Objects that are just created don't
-need to be invalidated.  This means we'll invalidate objects that
-dont' need to be invalidated, however, that's better than verifying
-caches.)
-
     >>> sv.close()
     >>> fs.close()
 
@@ -1016,7 +1007,10 @@ transaction, we'll get a result:
     True
 
     >>> sorted([int(u64(oid)) for oid in oids])
-    [0, 101, 102, 103, 104]
+    [0, 101, 102, 103, 104, 105]
+
+Note that in all cases invalidations include both modified objects and objects
+that were only created.
 
     >>> fs.close()
     """

--- a/src/ZEO/tests/testZEO2.py
+++ b/src/ZEO/tests/testZEO2.py
@@ -153,7 +153,9 @@ We can start another client and get the storage lock.
     >>> _ = zs1.vote('1') # doctest: +ELLIPSIS
     1 callAsync serialnos ...
 
-    >>> zs1.tpc_finish('1').set_sender(0, conn1)
+    >>> zs1.tpc_finish('1').set_sender(0, conn1) # doctest: +ELLIPSIS
+    1 callAsync invalidateTransaction ...
+    1 callAsync info ...
 
     >>> fs.close()
     """


### PR DESCRIPTION
This is ZEO4 backport of https://github.com/zopefoundation/ZEO/pull/160.

Please see details in the first patch.
I also had to backport 8d7b1ceb to get tests back to passing(*) becuase of previously hidden errror. Please see details in the second patch.

Thanks beforehand,
Kirill

/cc @jimfulton 

(*) to the same state as on current 4 branch.