### PR TITLE
client: Fix cache corruption on loadBefore and prefetch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 5.2.3 (unreleased)
 ------------------
 
+- Fix data corruption due to race between load and external invalidations.
+  See `issue 155 <https://github.com/zopefoundation/ZEO/issues/155>`_.
 
 5.2.2 (2020-08-11)
 ------------------


### PR DESCRIPTION
Currently loadBefore and prefetch spawn async protocol.load_before task,
and, after waking up on its completion, populate the cache with received
data. But in between the time when protocol.load_before handler is run
and the time when protocol.load_before caller wakes up, there is a
window in which event loop might be running some other code, including
the code that handles invalidateTransaction messages from the server.

This means that cache updates and cache invalidations can be processed on
the client not in the order that server sent it. And such difference in
the order can lead to data corruption if e.g server sent

	<- loadBefore oid serial=tid1 next_serial=None
	<- invalidateTransaction tid2 oid

and client processed it as

	invalidateTransaction tid2 oid
	cache.store(oid, tid1, next_serial=None)

because here the end effect is that invalidation for oid@tid2 is not
applied to the cache.

The fix is simple: perform cache updates right after loadBefore reply is
received.

Fixes: https://github.com/zopefoundation/ZEO/issues/155

The fix is based on analysis and initial patch by @jmuchemb:

https://github.com/zopefoundation/ZEO/issues/155#issuecomment-581046248

~~For tests, similarly to https://github.com/zopefoundation/ZODB/pull/345,
I wanted to include a general test for this issue into ZODB, so that all
storages - not just ZEO - are exercised for this race scenario. However
in ZODB test infrastructure there is currently no established general
way to open several client storage connections to one storage server.
This way the test for this issue currently lives in wendelin.core
repository (and exercises both NEO and ZEO there):~~

~~https://lab.nexedi.com/nexedi/wendelin.core/commit/c37a989d~~

~~I understand there is a room for improvement. For the reference, my
original ZEO-specific data corruption reproducer is here:~~

~~https://github.com/zopefoundation/ZEO/issues/155#issuecomment-577602842
https://lab.nexedi.com/kirr/wendelin.core/blob/ecd0e7f0/zloadrace5.py~~

**EDIT**: this fix now has corresponding test that should be coming in via https://github.com/zopefoundation/ZEO/pull/170 and https://github.com/zopefoundation/ZODB/pull/345.

/cc @d-maurer, @jamadden, @dataflake, @jimfulton