### PR TITLE
tests: Factor "Open another ClientStorage to the same server" into generic _new_storage_client()

### DIFF
--- a/src/ZEO/tests/CommitLockTests.py
+++ b/src/ZEO/tests/CommitLockTests.py
@@ -26,12 +26,6 @@ from ZEO.tests.TestThread import TestThread
 
 ZERO = b'\0'*8
 
-class DummyDB(object):
-    def invalidate(self, *args, **kwargs):
-        pass
-
-    transform_record_data = untransform_record_data = lambda self, data: data
-
 class WorkerThread(TestThread):
 
     # run the entire test in a thread so that the blocking call for
@@ -103,7 +97,7 @@ class CommitLockTests(object):
         self._threads = []
 
         for i in range(self.NUM_CLIENTS):
-            storage = self._duplicate_client()
+            storage = self._new_storage_client()
             txn = TransactionMetaData()
             tid = self._get_timestamp()
 
@@ -121,18 +115,6 @@ class CommitLockTests(object):
     def _finish_threads(self):
         for t in self._threads:
             t.cleanup()
-
-    def _duplicate_client(self):
-        "Open another ClientStorage to the same server."
-        # It's hard to find the actual address.
-        # The rpc mgr addr attribute is a list.  Each element in the
-        # list is a socket domain (AF_INET, AF_UNIX, etc.) and an
-        # address.
-        addr = self._storage._addr
-        new = ZEO.ClientStorage.ClientStorage(
-            addr, wait=1, **self._client_options())
-        new.registerDB(DummyDB())
-        return new
 
     def _get_timestamp(self):
         t = time.time()

--- a/src/ZEO/tests/testZEO.py
+++ b/src/ZEO/tests/testZEO.py
@@ -190,9 +190,7 @@ class MiscZEOTests(object):
         self._dostore(data=obj)
 
     def checkZEOInvalidation(self):
-        addr = self._storage._addr
-        storage2 = self._wrap_client(
-            ClientStorage(addr, wait=1, **self._client_options()))
+        storage2 = self._new_storage_client()
         try:
             oid = self._storage.new_oid()
             ob = MinPO('first')
@@ -220,14 +218,13 @@ class MiscZEOTests(object):
     def checkVolatileCacheWithImmediateLastTransaction(self):
         # Earlier, a ClientStorage would not have the last transaction id
         # available right after successful connection, this is required now.
-        addr = self._storage._addr
-        storage2 = ClientStorage(addr, **self._client_options())
+        storage2 = self._new_storage_client()
         self.assertTrue(storage2.is_connected())
         self.assertEqual(ZODB.utils.z64, storage2.lastTransaction())
         storage2.close()
 
         self._dostore()
-        storage3 = ClientStorage(addr, **self._client_options())
+        storage3 = self._new_storage_client()
         self.assertTrue(storage3.is_connected())
         self.assertEqual(8, len(storage3.lastTransaction()))
         self.assertNotEqual(ZODB.utils.z64, storage3.lastTransaction())
@@ -261,6 +258,15 @@ class GenericTestBase(
                 **self._client_options()),
             )
         self._storage.registerDB(DummyDB())
+
+    # _new_storage_client opens another ClientStorage to the same storage server
+    # self._storage is connected to. It is used by both ZEO and ZODB tests.
+    def _new_storage_client(self):
+        client = ZEO.ClientStorage.ClientStorage(
+            self._storage._addr, wait=1, **self._client_options())
+        client = self._wrap_client(client)
+        client.registerDB(DummyDB())
+        return client
 
     def getZEOConfig(self):
         return forker.ZEOConfig(('127.0.0.1', 0))
@@ -320,8 +326,7 @@ class GenericTests(
     def _do_store_in_separate_thread(self, oid, revid, voted):
 
         def do_store():
-            store = ZEO.ClientStorage.ClientStorage(
-                self._storage._addr, **self._client_options())
+            store = self._new_storage_client()
             try:
                 t = transaction.get()
                 store.tpc_begin(t)


### PR DESCRIPTION
This allows ZODB tests to recognize ZEO as client-server storage and so
make "load vs external invalidate" test added in
https://github.com/zopefoundation/ZODB/pull/345 to reproduce data
corruption problem reported at
https://github.com/zopefoundation/ZEO/issues/155.

For the reference: that problem should be fixed by
https://github.com/zopefoundation/ZEO/pull/169.

We drop

    # It's hard to find the actual address.
    # The rpc mgr addr attribute is a list.  Each element in the
    # list is a socket domain (AF_INET, AF_UNIX, etc.) and an
    # address.

note because at the time it was added (81f586c4) it came with

    addr = self._storage._rpc_mgr.addr[0][1]

but nowdays after 03867188 getting to server address is just by ClientStorage._addr.