### PR TITLE
hunt for the drop cache race condition

### DIFF
--- a/src/ZEO/tests/drop_cache_rather_than_verify.txt
+++ b/src/ZEO/tests/drop_cache_rather_than_verify.txt
@@ -78,7 +78,7 @@ Now, we'll restart the server on the original address:
 ##### debugging only ########
     >>> print(db.storage._server.client.verify_result)
     cache too old, clearing
-    >>> print(len(handler.records) > 1 and handler)
+    >>> print(len(handler.records) > 1 and str(handler) + handler.records[0].exc_text)
     False
 
 Now, let's verify our assertions above:
@@ -150,7 +150,7 @@ in the database, which is why we get 1, rather than 0 objects in the cache.)
 ##### debugging only ########
     >>> print(db.storage._server.client.verify_result)
     cache too old, clearing
-    >>> print(len(handler.records) > 1 and handler)
+    >>> print(len(handler.records) > 1 and str(handler) + handler.records[0].exc_text)
     False
 
 - Publishes a stale-cache event.

--- a/src/ZEO/tests/drop_cache_rather_than_verify.txt
+++ b/src/ZEO/tests/drop_cache_rather_than_verify.txt
@@ -78,6 +78,8 @@ Now, we'll restart the server on the original address:
 ##### debugging only ########
     >>> print(db.storage._server.client.verify_result)
     cache too old, clearing
+    >>> print(len(handler.records) > 1 and handler)
+    False
 
 Now, let's verify our assertions above:
 
@@ -148,6 +150,8 @@ in the database, which is why we get 1, rather than 0 objects in the cache.)
 ##### debugging only ########
     >>> print(db.storage._server.client.verify_result)
     cache too old, clearing
+    >>> print(len(handler.records) > 1 and handler)
+    False
 
 - Publishes a stale-cache event.
 

--- a/src/ZEO/tests/drop_cache_rather_than_verify.txt
+++ b/src/ZEO/tests/drop_cache_rather_than_verify.txt
@@ -59,7 +59,7 @@ logging and event data:
     >>> def event_handler(e):
     ...   if hasattr(e, 'storage'):
     ...     events.append((
-    ...       len(e.storage._server.client.cache), str(handler), e.__class__.__name__))
+    ...       len(e.storage._cache), str(handler), e.__class__.__name__))
 
     >>> old_notify = ZODB.event.notify
     >>> ZODB.event.notify = event_handler
@@ -74,12 +74,6 @@ Now, we'll restart the server on the original address:
     ...                         addr=addr, keep=1)
 
     >>> wait_connected(db.storage)
-
-##### debugging only ########
-    >>> print(db.storage._server.client.verify_result)
-    cache too old, clearing
-    >>> print(len(handler.records) > 1 and str(handler) + handler.records[0].exc_text)
-    False
 
 Now, let's verify our assertions above:
 
@@ -146,12 +140,6 @@ another client:
 
 (When a database is created, it checks to make sure the root object is
 in the database, which is why we get 1, rather than 0 objects in the cache.)
-
-##### debugging only ########
-    >>> print(db.storage._server.client.verify_result)
-    cache too old, clearing
-    >>> print(len(handler.records) > 1 and str(handler) + handler.records[0].exc_text)
-    False
 
 - Publishes a stale-cache event.
 


### PR DESCRIPTION
This PR adds more debugging code in the hope to understand the race condition in the `drop_cache_rather_than_verity` test. In my local environment, the race does not occur. Thus, the need to use the github tests (where the race sometimes occurs).