### PR TITLE
tpc_vote/abort + log message enhancements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,11 +4,27 @@ Changelog
 5.3.1 (unreleased)
 ------------------
 
+- Add ``ConflictError`` to the list of unlogged server exceptions
+  (the client/its application should determine whether it wants
+  them logged).
+
+  Prevent ``no current transaction: tpc_abort()`` server log entries.
+  The storage API allows ``tpc_abort`` to be called with an
+  invalid transaction (the call should be ignored in this case)
+  and the server's ``tpc_vote`` relies on this.
+
+  Change the server's log message label for request exceptions
+  from ``Bad request ...`` to ``... raised exception:``,
+  hinting towards a server rather than client problem.
+
+  See `issue 156 <https://github.com/zopefoundation/ZEO/issues/156>`_.
+
+
 
 5.3.0 (2022-03-24)
 ------------------
 
-- Remove tests for the `asyncio/mtacceptor` module, it appears unused
+- Remove tests for the ``asyncio/mtacceptor`` module, it appears unused
   and presents a maintenance burden. The module will be removed in
   ZEO version 6.
 

--- a/src/ZEO/asyncio/server.py
+++ b/src/ZEO/asyncio/server.py
@@ -24,6 +24,7 @@ class ServerProtocol(base.Protocol):
 
     unlogged_exception_types = (
         ZODB.POSException.POSKeyError,
+        ZODB.POSException.ConflictError,
         )
 
     def __init__(self, loop, addr, zeo_storage, msgpack):
@@ -104,7 +105,8 @@ class ServerProtocol(base.Protocol):
         except Exception as exc:
             if not isinstance(exc, self.unlogged_exception_types):
                 logger.exception(
-                    "Bad %srequest, %r", 'async ' if async_ else '', name)
+                    "%s`%r` raised exception:",
+                    'async ' if async_ else '', name)
             if async_:
                 return self.close() # No way to recover/cry for help
             else:


### PR DESCRIPTION
Fixes #156.

This PR
* adds `ConflictError` to the list of exceptions not logged by the server: this exception is expected to be raised by server operations; the client/its application should decide whether it wants it logged.
* suppress server log message `no current transaction: tpc_abort()`. The storage API allows `tpc_abort` to be called with an invalid transaction (the call should be ignored in this case); the server's `tpc_vote` implementation invalidates the transaction in case of errors and thereby relies on a call of `tpc_abort` with an invalid transaction.
* changes the label for log messages reporting exceptions in server calls from `Bad request ...` to `... raised exception:`.