### PR TITLE
Reduce ZEO testing time by dropping tests with some storages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,18 @@ Changelog
 5.4.0 (unreleased)
 ------------------
 
+- Test ZEO only with the following storages
+  ``FileStorage`` with server side blobs,
+  ``FileStorage`` with shared blob directory,
+  ``MappingStorage`` (without blobs).
+
+  Those tests cover all storage features with impact on ZEO:
+  without blobs, with shared blobs and with server side blobs;
+  load, store, two phase commit, undo.
+  Therefore, passing tests for those storages provide high confidence that ZEO
+  works for other properly implemented storages as well.
+  See `#198 <https://github.com/zopefoundation/ZEO/issues/198>`_.
+
 - Lint the code with flake8
 
 - Add support for Python 3.10.

--- a/src/ZEO/tests/testZEO.py
+++ b/src/ZEO/tests/testZEO.py
@@ -1744,9 +1744,10 @@ slow_test_classes = [
     # and with in memory store (may have different latency than
     # ``FileStorage`` and therefore expose other race conditions)
     MappingStorageTests,
-#   DemoStorageTests,
-#   FileStorageTests,
-#   FileStorageHexTests, FileStorageClientHexTests,
+    # drop to save time
+    #   DemoStorageTests,
+    #   FileStorageTests,
+    #   FileStorageHexTests, FileStorageClientHexTests,
     ]
 if not forker.ZEO4_SERVER:
     slow_test_classes.append(FileStorageSSLTests)

--- a/src/ZEO/tests/testZEO.py
+++ b/src/ZEO/tests/testZEO.py
@@ -1740,9 +1740,13 @@ def can_use_empty_string_for_local_host_on_client():
 
 slow_test_classes = [
     BlobAdaptedFileStorageTests, BlobWritableCacheTests,
-    MappingStorageTests, DemoStorageTests,
-    FileStorageTests,
-    FileStorageHexTests, FileStorageClientHexTests,
+    # keep to test a storage without blobs
+    # and with in memory store (may have different latency than
+    # ``FileStorage`` and therefore expose other race conditions)
+    MappingStorageTests,
+#   DemoStorageTests,
+#   FileStorageTests,
+#   FileStorageHexTests, FileStorageClientHexTests,
     ]
 if not forker.ZEO4_SERVER:
     slow_test_classes.append(FileStorageSSLTests)


### PR DESCRIPTION
Fixes #198.

The ZEO tests have the task to verify proper ZEO functioning, not to test storages. If ZEO works correctly and a storage works correctly, then ZEO should work correctly with this storage.

This PR drops the ZEO tests with the storages `DemoStorage`, `FileStorage` without blobs, `HexFileStorage` and `ClientHexFileStorage`. It retains the tests with `Filestorage` with shared or server side blobs and `MappingStorage`.

The `MappingStorage` tests cover the case "storage without blobs". It is used instead of `FileStorage` without blobs to increase the chance to detect race conditions (`MappingStorage` has slightly different latency from `FileStorage` because the data is stored in RAM rather than on disk).