### PR TITLE
Run tests at all levels

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -16,9 +16,9 @@ with-sphinx-doctests = false
 use-flake8 = true
 testenv-commands = [
     "# Run unit tests first.",
-    "zope-testrunner -u --test-path=src {posargs:-vc}",
+    "zope-testrunner -u --test-path=src --all {posargs:-vc}",
     "# Only run functional tests if unit tests pass.",
-    "zope-testrunner -f --test-path=src {posargs:-vc}",
+    "zope-testrunner -f --test-path=src --all {posargs:-vc}",
     ]
 testenv-deps = [
     "!zodbmaster: ZODB >= 4.2.0b1",

--- a/.meta.toml
+++ b/.meta.toml
@@ -16,9 +16,9 @@ with-sphinx-doctests = false
 use-flake8 = true
 testenv-commands = [
     "# Run unit tests first.",
-    "zope-testrunner -u --test-path=src --all {posargs:-vc}",
+    "zope-testrunner -u --test-path=src -a 1000 {posargs:-vc}",
     "# Only run functional tests if unit tests pass.",
-    "zope-testrunner -f --test-path=src --all {posargs:-vc}",
+    "zope-testrunner -f --test-path=src -a 1000 {posargs:-vc}",
     ]
 testenv-deps = [
     "!zodbmaster: ZODB >= 4.2.0b1",

--- a/tox.ini
+++ b/tox.ini
@@ -28,9 +28,9 @@ setenv =
     zeo4: ZEO4_SERVER=1
 commands =
     # Run unit tests first.
-    zope-testrunner -u --test-path=src --all {posargs:-vc}
+    zope-testrunner -u --test-path=src -a 1000 {posargs:-vc}
     # Only run functional tests if unit tests pass.
-    zope-testrunner -f --test-path=src --all {posargs:-vc}
+    zope-testrunner -f --test-path=src -a 1000 {posargs:-vc}
 extras =
     test
 

--- a/tox.ini
+++ b/tox.ini
@@ -28,9 +28,9 @@ setenv =
     zeo4: ZEO4_SERVER=1
 commands =
     # Run unit tests first.
-    zope-testrunner -u --test-path=src {posargs:-vc}
+    zope-testrunner -u --test-path=src --all {posargs:-vc}
     # Only run functional tests if unit tests pass.
-    zope-testrunner -f --test-path=src {posargs:-vc}
+    zope-testrunner -f --test-path=src --all {posargs:-vc}
 extras =
     test
 


### PR DESCRIPTION
Since https://github.com/zopefoundation/ZODB/commit/a94d63c552d6 (part
of https://github.com/zopefoundation/ZODB/pull/368) some ZODB tests are
marked as being long to help skipping them easily during development via
running tests only at level 1.

But by default we want to continue to run all tests.

-> Adjust tox to run tests at all levels explicitly, since
zope-testrunner's default is to run tests at level 1 only.