### PR TITLE
exit value is 1 if all connection to servers fail

### DIFF
--- a/src/ZEO/scripts/zeopack.py
+++ b/src/ZEO/scripts/zeopack.py
@@ -169,6 +169,7 @@ def _main(args=None, prog=None):
     if not server_found:
         error("Cannot connect to any of the configured ZEO servers.")
 
+
 def main(*args):
     root_logger = logging.getLogger()
     old_level = root_logger.getEffectiveLevel()

--- a/src/ZEO/scripts/zeopack.py
+++ b/src/ZEO/scripts/zeopack.py
@@ -145,12 +145,14 @@ def _main(args=None, prog=None):
     if not servers:
         error("No servers specified.")
 
+    server_found = False
     for addr, name in servers:
         try:
             cs = ZEO.ClientStorage.ClientStorage(
                 addr, storage=name, wait=False, read_only=1)
             for i in range(60):
                 if cs.is_connected():
+                    server_found = True
                     break
                 time.sleep(1)
             else:
@@ -164,6 +166,8 @@ def _main(args=None, prog=None):
             traceback.print_exception(*(sys.exc_info()+(99, sys.stderr)))
             error("Error packing storage %s in %r" % (name, addr))
 
+    if not server_found:
+        error("No servers found.")
 
 def main(*args):
     root_logger = logging.getLogger()

--- a/src/ZEO/scripts/zeopack.py
+++ b/src/ZEO/scripts/zeopack.py
@@ -167,7 +167,7 @@ def _main(args=None, prog=None):
             error("Error packing storage %s in %r" % (name, addr))
 
     if not server_found:
-        error("No servers found.")
+        error("Cannot connect to any of the configured ZEO servers.")
 
 def main(*args):
     root_logger = logging.getLogger()

--- a/src/ZEO/scripts/zeopack.test
+++ b/src/ZEO/scripts/zeopack.test
@@ -202,6 +202,9 @@ seconds of waiting for a connect.
     sleep(1)
     Couldn't connect to: (('host1', 8100), '2')
     close()
+    Error:
+    Cannot connect to any of the configured ZEO servers.
+    Exited 1
 
     >>> ClientStorage.connect_wait = 0
 


### PR DESCRIPTION
closes: #214

This PR changes the `zeopack` exit value to 1 when all connections to server are a failure. Currently, `zeopack` outputs `Couldn't connect to: xxx` and exits with 0. I think it should be an error exit value than a succes. 

The usecase is described in #214. This PR implements  the solution **a** (as defined in issue #214) because the [`usage`](https://github.com/zopefoundation/ZEO/blob/83730901e5d7bcb0916d5391f5907e5f9d3a32e7/src/ZEO/scripts/zeopack.py#L12) constant documents `zeopack` as `Pack one or more storages hosted by ZEO servers`.