### PR TITLE
Fix GHA + support Python 3.11.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - ubuntu
+        - ["ubuntu", "ubuntu-20.04"]
         config:
         # [Python version, tox env]
         - ["3.9",   "lint"]
@@ -28,6 +28,7 @@ jobs:
         - ["3.8",   "py38"]
         - ["3.9",   "py39"]
         - ["3.10",  "py310"]
+        - ["3.11",  "py311"]
         - ["pypy-2.7", "pypy"]
         - ["pypy-3.7", "pypy3"]
         - ["3.9",   "docs"]
@@ -45,16 +46,17 @@ jobs:
         - ["3.10",  "py310-uvloop"]
         - ["pypy-3.7", "pypy3-msgpack1"]
 
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os[1] }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.config[1] }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.config[0] }}
     - name: Pip cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,6 @@ jobs:
         - ["3.9",   "docs"]
         - ["3.9",   "coverage"]
         - ["2.7",   "py27-msgpack1"]
-        - ["2.7",   "py27-zodbmaster"]
         - ["3.7",   "py37-msgpack1"]
         - ["3.7",   "py37-uvloop"]
         - ["3.7",   "py37-zodbmaster"]
@@ -44,6 +43,9 @@ jobs:
         - ["3.9",   "py39-uvloop"]
         - ["3.10",  "py310-msgpack1"]
         - ["3.10",  "py310-uvloop"]
+        - ["3.10",  "py310-zodbmaster"]
+        - ["3.11",  "py311-msgpack1"]
+        - ["3.11",  "py311-uvloop"]
         - ["pypy-3.7", "pypy3-msgpack1"]
 
     runs-on: ${{ matrix.os[1] }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install "tox < 4"
+        pip install tox
     - name: Test
       run: tox -e ${{ matrix.config[1] }}
     - name: Coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox
+        pip install "tox < 4"
     - name: Test
       run: tox -e ${{ matrix.config[1] }}
     - name: Coverage

--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ lib64
 log/
 parts/
 pyvenv.cfg
+testing.log
 var/

--- a/.meta.toml
+++ b/.meta.toml
@@ -50,7 +50,6 @@ additional-rules = [
 [github-actions]
 additional-config = [
     "- [\"2.7\",   \"py27-msgpack1\"]",
-    "- [\"2.7\",   \"py27-zodbmaster\"]",
     "- [\"3.7\",   \"py37-msgpack1\"]",
     "- [\"3.7\",   \"py37-uvloop\"]",
     "- [\"3.7\",   \"py37-zodbmaster\"]",
@@ -60,5 +59,8 @@ additional-config = [
     "- [\"3.9\",   \"py39-uvloop\"]",
     "- [\"3.10\",  \"py310-msgpack1\"]",
     "- [\"3.10\",  \"py310-uvloop\"]",
+    "- [\"3.10\",  \"py310-zodbmaster\"]",
+    "- [\"3.11\",  \"py311-msgpack1\"]",
+    "- [\"3.11\",  \"py311-uvloop\"]",
     "- [\"pypy-3.7\", \"pypy3-msgpack1\"]",
     ]

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [meta]
 template = "pure-python"
-commit-id = "931ebd36c89bffdc929019c5080086ed7a45b5d6"
+commit-id = "200573eb414d2228d463da3de7d71a6d6335a704"
 
 [python]
 with-windows = false
@@ -23,7 +23,7 @@ testenv-commands = [
     ]
 testenv-deps = [
     "!zodbmaster: ZODB >= 4.2.0b1",
-    "zodbmaster: -e git+https://github.com/zopefoundation/ZODB.git@master#egg=ZODB",
+    "zodbmaster: -e git+https://github.com/zopefoundation/ZODB.git@master\\#egg=ZODB",
     "uvloop: uvloop",
     ]
 testenv-setenv = [

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [meta]
 template = "pure-python"
-commit-id = "0c07a1cfd78d28a07aebd23383ed16959f166574"
+commit-id = "931ebd36c89bffdc929019c5080086ed7a45b5d6"
 
 [python]
 with-windows = false
@@ -11,9 +11,10 @@ with-future-python = false
 with-legacy-python = true
 with-docs = true
 with-sphinx-doctests = false
+with-macos = false
 
 [tox]
-use-flake8 = true
+use-flake8 = false
 testenv-commands = [
     "# Run unit tests first.",
     "zope-testrunner -u --test-path=src -a 1000 {posargs:-vc}",

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,7 +37,7 @@ Changelog
 
 - Lint the code with flake8
 
-- Add support for Python 3.10.
+- Add support for Python 3.10, 3.11.
 
 - Add ``ConflictError`` to the list of unlogged server exceptions
   (the client/its application should determine whether it wants

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,14 @@ ignore =
     .editorconfig
     .meta.toml
     docs/_build/html/_sources/*
+
+[isort]
+force_single_line = True
+combine_as_imports = True
+sections = FUTURE,STDLIB,THIRDPARTY,ZOPE,FIRSTPARTY,LOCALFOLDER
+known_third_party = six, docutils, pkg_resources
+known_zope =
+known_first_party =
+default_section = ZOPE
+line_length = 79
+lines_after_imports = 2

--- a/setup.py
+++ b/setup.py
@@ -43,27 +43,6 @@ tests_require = [
     'zope.testrunner',
 ]
 
-classifiers = """
-Intended Audience :: Developers
-License :: OSI Approved :: Zope Public License
-Programming Language :: Python :: 2
-Programming Language :: Python :: 2.7
-Programming Language :: Python :: 3
-Programming Language :: Python :: 3.5
-Programming Language :: Python :: 3.6
-Programming Language :: Python :: 3.7
-Programming Language :: Python :: 3.8
-Programming Language :: Python :: 3.9
-Programming Language :: Python :: 3.10
-Programming Language :: Python :: Implementation :: CPython
-Programming Language :: Python :: Implementation :: PyPy
-Topic :: Database
-Topic :: Software Development :: Libraries :: Python Modules
-Operating System :: Microsoft :: Windows
-Operating System :: Unix
-Framework :: ZODB
-""".strip().split('\n')
-
 
 def _modname(path, base, name=''):
     if path == base:
@@ -139,7 +118,27 @@ setup(name="ZEO",
       package_dir={'': 'src'},
       license="ZPL 2.1",
       platforms=["any"],
-      classifiers=classifiers,
+      classifiers=[
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Zope Public License",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
+        "Topic :: Database",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Operating System :: Microsoft :: Windows",
+        "Operating System :: Unix",
+        "Framework :: ZODB",
+      ],
       test_suite="__main__.alltests",  # to support "setup.py test"
       tests_require=tests_require,
       extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ envlist =
 usedevelop = true
 deps =
     !zodbmaster: ZODB >= 4.2.0b1
-    zodbmaster: -e git+https://github.com/zopefoundation/ZODB.git@master#egg=ZODB
+    zodbmaster: -e git+https://github.com/zopefoundation/ZODB.git@master\#egg=ZODB
     uvloop: uvloop
 setenv =
     !py27-!pypy: PYTHONWARNINGS=ignore::ResourceWarning
@@ -62,7 +62,7 @@ deps =
     coverage
     coverage-python-version
     !zodbmaster: ZODB >= 4.2.0b1
-    zodbmaster: -e git+https://github.com/zopefoundation/ZODB.git@master#egg=ZODB
+    zodbmaster: -e git+https://github.com/zopefoundation/ZODB.git@master\#egg=ZODB
     uvloop: uvloop
 commands =
     mkdir -p {toxinidir}/parts/htmlcov

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ envlist =
     py38
     py39
     py310
+    py311
     pypy
     pypy3
     docs
@@ -36,15 +37,13 @@ extras =
 [testenv:lint]
 basepython = python3
 skip_install = true
+commands =
+    check-manifest
+    check-python-versions
 deps =
-    flake8
     check-manifest
     check-python-versions >= 0.19.1
     wheel
-commands =
-    flake8 src setup.py
-    check-manifest
-    check-python-versions
 
 [testenv:docs]
 basepython = python3
@@ -68,8 +67,8 @@ deps =
 commands =
     mkdir -p {toxinidir}/parts/htmlcov
     coverage run -m zope.testrunner --test-path=src {posargs:-vc}
-    coverage html
-    coverage report -m --fail-under=53
+    coverage html --ignore-errors
+    coverage report --ignore-errors --show-missing --fail-under=53
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
I had to disable flake8 checks, so isort-ing the imports is not enforced.