### PR TITLE
Optimize via direct socket access with loop lock concurrency protection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,13 @@ Changelog
   ``password`` - support for such basic auth was dropped in 2016 before ZEO 5.0
   was released.
 
+- Optimize ZEO server interactions in typical cases
+  (e.g. no SSL, no ``uvloop``) by allowing client application
+  threads to access the server communication socket directly.
+  This can speed up ZEO operations considerable, especially reads.
+  For details see
+  `#225 <https://github.com/zopefoundation/ZEO/pull/225>`_.
+
 
 5.4.0 (2023-01-18)
 ------------------

--- a/src/ZEO/asyncio/futures.py
+++ b/src/ZEO/asyncio/futures.py
@@ -246,7 +246,6 @@ class CoroutineExecutor:
                 result = self.coro.send(await_result)
             else:
                 result = self.coro.throw(await_result)
-
         except BaseException as e:
             # we are done
             task = self.task
@@ -388,6 +387,7 @@ class FastConcurrentTask(ConcurrentTask):
 try:
     from ._futures import Future, ConcurrentFuture  # noqa: F401, F811
     from ._futures import AsyncTask, ConcurrentTask  # noqa: F401, F811
+    from ._futures import FastConcurrentTask  # noqa: F401, F811
     from ._futures import switch_thread  # noqa: F401, F811
 except ImportError:
     pass


### PR DESCRIPTION
Alternative (wrt #224) optimization following @navytux idea to access the socket directly.
While #224 monkey patches the write operation to include a synchronizing lock, this PR monkey patches the loop and includes a loop lock which ensures that an application thread cannot execute a task step while the loop processes callbacks.

Initially, I had hoped that this approach would work for SSL connections, too. But the SSL writes include non thread safe loop operations. Thus, like for #224, SSL access cannot be optimized.

Nevertheless, this approach is simpler and therefore potentially more reliable.