### PR TITLE
Fix #226 using a standard `asyncio.Task` 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@ Changelog
 5.4.1 (unreleased)
 ------------------
 
+- Fix `#226 <https://github.com/zopefoundation/ZEO/issues/226>`_
+  using an ``asyncio.Task`` (rather than a proprietary,
+  specially ZEO optimized task) for the connection process.
+  This is advisable because the connection process is not
+  implemented by ZEO but by foreign code which may
+  have problems with the limitations of ZEO tasks.
+
 
 5.4.0 (2023-01-18)
 ------------------

--- a/src/ZEO/asyncio/client.py
+++ b/src/ZEO/asyncio/client.py
@@ -159,7 +159,11 @@ class Protocol(base.ZEOBaseProtocol):
             cr = lambda: self.loop.create_unix_connection(  # noqa: E731
                 self.protocol_factory, self.addr, ssl=self.ssl)
 
-        self._connecting = asyncio.Task(
+        # Usually, we use our optimized but feature limited tasks
+        # to run coroutines. Here we use a standard task
+        # because we do not know which task features the connect
+        # coroutine needs.
+        self._connecting = self.loop.create_task(
             connect_coroutine(cr, self, logger, local_random.random),
             loop=self.loop)
 

--- a/src/ZEO/asyncio/client.py
+++ b/src/ZEO/asyncio/client.py
@@ -164,8 +164,7 @@ class Protocol(base.ZEOBaseProtocol):
         # because we do not know which task features the connect
         # coroutine needs.
         self._connecting = self.loop.create_task(
-            connect_coroutine(cr, self, logger, local_random.random),
-            loop=self.loop)
+            connect_coroutine(cr, self, logger, local_random.random))
 
     def connection_made(self, transport):
         logger.debug('connection_made %s', self)

--- a/src/ZEO/asyncio/connectco_2.py
+++ b/src/ZEO/asyncio/connectco_2.py
@@ -1,0 +1,19 @@
+"""Python 2 implementation for ``connect_coroutine``."""
+
+from .compat import asyncio
+
+@asyncio.coroutine
+def connect_coroutine(cr, self, logger, random):
+    while not self.closed:
+        try:
+            yield cr()
+            return
+        except asyncio.CancelledError:
+            logger.info("Connection to %r cancelled", self.addr)
+            raise
+        except Exception as exc:
+            logger.info("Connection to %r failed, %s",
+                        self.addr, exc)
+        yield asyncio.sleep(self.connect_poll + random())
+        logger.info("retry connecting %r", self.addr)
+

--- a/src/ZEO/asyncio/connectco_3.py
+++ b/src/ZEO/asyncio/connectco_3.py
@@ -1,0 +1,17 @@
+"""Python 3 implementation for ``connect_coroutine``."""
+
+from .compat import asyncio
+
+async def connect_coroutine(cr, self, logger, random):
+    while not self.closed:
+        try:
+            return await cr()
+        except asyncio.CancelledError:
+            logger.info("Connection to %r cancelled", self.addr)
+            raise
+        except Exception as exc:
+            logger.info("Connection to %r failed, %s",
+                        self.addr, exc)
+        await asyncio.sleep(self.connect_poll + random())
+        logger.info("retry connecting %r", self.addr)
+


### PR DESCRIPTION
Fixes #226.

This PR is an alternative to #227. Both fix #226.
While #227 fixes the immediate cause for the #226 failure, i.e. the connection process had made the implicit assumption that the loop was already running not fulfilled with ZEO, this PR approaches the problem in a more general way: the connection process is not implemented by ZEO but by foreign code; this code may expect a standard `Task`/coroutine executor, not the optimized but limited one of the ZEO implementation. For this reason, this PR uses a standard `asyncio.Task` to control the connection process.
A standard `Task` automatically ensures that its first step is only run when the loop is running.