### PR TITLE
Drop `ZEO.monitor.zeo_version` and `pkg_resources`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ Changelog
 
 - Drop support for Python 3.7, 3.8.
 
+- Drop ``ZEO.monitor.zeo_version`` as it is unused across all zopefoundation
+  packages.
+
+- No longer use deprecated ``pkg_resources``.
 
 6.0.0 (2023-11-23)
 ------------------

--- a/src/ZEO/monitor.py
+++ b/src/ZEO/monitor.py
@@ -17,19 +17,6 @@
 import time
 
 
-zeo_version = 'unknown'
-try:
-    import pkg_resources
-except ModuleNotFoundError:
-    pass
-else:
-    zeo_dist = pkg_resources.working_set.find(
-        pkg_resources.Requirement.parse('ZODB3')
-    )
-    if zeo_dist is not None:
-        zeo_version = zeo_dist.version
-
-
 class StorageStats:
     """Per-storage usage statistics."""
 

--- a/src/ZEO/nagios.rst
+++ b/src/ZEO/nagios.rst
@@ -6,8 +6,11 @@ ZEO includes a script that provides a nagios monitor plugin:
 
     >>> import time
     >>> import importlib.metadata
-    >>> nagios = importlib.metadata.entry_points(
-    ...     group='console_scripts')['zeo-nagios'].load()
+    >>> try:
+    ...     nagios = importlib.metadata.entry_points(
+    ...         group='console_scripts')['zeo-nagios'].load()
+    ... except TypeError:  # PY39
+    ...     from ZEO.nagios import main as nagios
 
 In it's simplest form, the script just checks if it can get status:
 

--- a/src/ZEO/nagios.rst
+++ b/src/ZEO/nagios.rst
@@ -4,9 +4,10 @@ ZEO Nagios plugin
 
 ZEO includes a script that provides a nagios monitor plugin:
 
-    >>> import pkg_resources, time
-    >>> nagios = pkg_resources.load_entry_point(
-    ...     'ZEO', 'console_scripts', 'zeo-nagios')
+    >>> import time
+    >>> import importlib.metadata
+    >>> nagios = importlib.metadata.entry_points(
+    ...     group='console_scripts')['zeo-nagios'].load()
 
 In it's simplest form, the script just checks if it can get status:
 


### PR DESCRIPTION
- `ZEO.monitor.zeo_version`  is unused across all zopefoundation packages.

- `pkg_resources` is deprecated.