### PR TITLE
Fix ZEO cache tracing wrt 2038 year

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 6.2 (unreleased)
 ----------------
 
+- Fix ZEO cache tracing to work after year 2038.
+
 - Add support for Python 3.14.
 
 - Drop support for Python 3.9.

--- a/src/ZEO/cache.py
+++ b/src/ZEO/cache.py
@@ -811,7 +811,7 @@ class ClientCache:
                 end_tid = z64
             try:
                 _tracefile.write(
-                    pack(">iiH8s8s",
+                    pack(">IiH8s8s",
                          int(now()), encoded, len(oid), tid, end_tid) + oid,
                 )
             except:  # NOQA: E722 bare except

--- a/src/ZEO/scripts/cache_simul.py
+++ b/src/ZEO/scripts/cache_simul.py
@@ -75,7 +75,7 @@ def main(args=None):
     # Read trace file, simulating cache behavior.
     f_read = f.read
     unpack = struct.unpack
-    FMT = ">iiH8s8s"
+    FMT = ">IiH8s8s"
     FMT_SIZE = struct.calcsize(FMT)
     assert FMT_SIZE == 26
 

--- a/src/ZEO/scripts/cache_stats.py
+++ b/src/ZEO/scripts/cache_stats.py
@@ -146,7 +146,7 @@ def main(args=None):
     thisinterval = None  # generally te//interval
     f_read = f.read
     unpack = struct.unpack
-    FMT = ">iiH8s8s"
+    FMT = ">IiH8s8s"
     FMT_SIZE = struct.calcsize(FMT)
     assert FMT_SIZE == 26
     # Read file, gathering statistics, and printing each record if verbose.


### PR DESCRIPTION
@bmwiedemann reports that ZEO tests fail in year 2038. From https://github.com/zopefoundation/ZEO/issues/245:

    Failure in test cache_simul_properly_handles_load_miss_after_eviction_and_inval (ZEO.tests.test_cache)
    Failed doctest test for ZEO.tests.test_cache.cache_simul_properly_handles_load_miss_after_eviction_and_inval
      File "/home/abuild/rpmbuild/BUILD/python-ZEO-6.1-build/zeo-6.1/src/ZEO/tests/test_cache.py", line 1015, in cache_simul_properly_handles_load_miss_after_eviction_and_inval

    ----------------------------------------------------------------------
    File "/home/abuild/rpmbuild/BUILD/python-ZEO-6.1-build/zeo-6.1/src/ZEO/tests/test_cache.py", line 1021, in ZEO.tests.test_cache.cache_simul_properly_handles_load_miss_after_eviction_and_inval
    Failed example:
        cache = ZEO.cache.ClientCache('cache', 1<<21)
    Exception raised:
        Traceback (most recent call last):
          File "/usr/lib64/python3.11/doctest.py", line 1355, in __run
            exec(compile(example.source, filename, "single",
          File "<doctest ZEO.tests.test_cache.cache_simul_properly_handles_load_miss_after_eviction_and_inval[1]>", line 1, in <module>
            cache = ZEO.cache.ClientCache('cache', 1<<21)
          File "/home/abuild/rpmbuild/BUILD/python-ZEO-6.1-build/zeo-6.1/src/ZEO/cache.py", line 239, in __init__
            self._setup_trace(path)
          File "/home/abuild/rpmbuild/BUILD/python-ZEO-6.1-build/zeo-6.1/src/ZEO/cache.py", line 823, in _setup_trace
            _trace(0x00)
          File "/home/abuild/rpmbuild/BUILD/python-ZEO-6.1-build/zeo-6.1/src/ZEO/cache.py", line 814, in _trace
            pack(">iiH8s8s",
        struct.error: 'i' format requires -2147483648 <= number <= 2147483647

Unfortunately as ZEO/scripts/cache_stats.py and ZEO/scripts/cache_simul.py show ZEO cache-trace files do not have header nor magic, so we cannot change format of time field from 32-bit integer to 64-bit integer without backward compatibility breakage. But there is a hack: we can change the format from 32-bit signed int to 32-bit unsigned int and gain support till 2106 in backward compatible manner:

    In [11]: time.ctime((1 << 32) - 1)
    Out[11]: 'Sun Feb  7 09:28:15 2106'

    In [12]: time.ctime((1 << 31) - 1)
    Out[12]: 'Tue Jan 19 06:14:07 2038'

-> Do that to keep binary compatibility and give us another 70 years to find a proper solution similarly to how mariadb did it.

/reported-and-helped-by @bmwiedemann
/fixes https://github.com/zopefoundation/ZEO/issues/245

- [x] I signed and returned the [Zope Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the zopefoundation GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Developer guidelines](https://www.zope.dev/developer/guidelines.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added documentation for my changes.
- [x] I included a change log entry in my commits.

/cc @icemac, @d-maurer 

Closes #245 
